### PR TITLE
feat(contractInfoTable) - Added a contract info table which we will keep upto date - Recreated - [TECH-911] 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -287,12 +287,12 @@ commands:
           name: Build Docker image
           command: |
             echo Using SHA $(cat tmp/gitsha | head -c7)
-            docker build -t << pipeline.parameters.ecr-repo >>:$(cat tmp/gitsha | head -c7) .
+            docker build -t << pipeline.parameters.ecr-repo >>:sha-$(cat tmp/gitsha | head -c7) .
       - run:
           name: Push Image to ECR
           command: |
             echo Using SHA $(cat tmp/gitsha | head -c7)
-            docker push << pipeline.parameters.ecr-repo >>:$(cat tmp/gitsha | head -c7)
+            docker push << pipeline.parameters.ecr-repo >>:sha-$(cat tmp/gitsha | head -c7)
 
   deploy-app:
     description: These steps deploy to a env.
@@ -320,9 +320,7 @@ commands:
 
       - run:
           name: Upgrade or install helm charts
-          command:
-            helm upgrade --install fortuna-<< parameters.kube-deploy-file-path >> fortuna-charts/fortuna-<< parameters.kube-deploy-file-path >>-chart
-
+          command: helm upgrade --install fortuna-<< parameters.kube-deploy-file-path >> fortuna-charts/fortuna-<< parameters.kube-deploy-file-path >>-chart
 
   tear-down:
     steps:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -31,14 +31,6 @@ jobs:
             ${{ runner.OS }}-build-
             ${{ runner.OS }}-
 
-      - name: setup doppler
-        uses: dopplerhq/cli-action@v1
-
-      - name: Pass all secrets to next steps
-        env:
-          DOPPLER_TOKEN: ${{ secrets.DOPPLER_PRD_SECRET_TOKEN }}
-        run: doppler secrets download --no-file --format=docker >> $GITHUB_ENV;
-
       - name: Install Dependencies
         run: NODE_ENV=development npm install
 

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -41,6 +41,59 @@
     {
       "type": "node",
       "request": "launch",
+      "name": "Update Contract Info",
+      "program": "${workspaceFolder}/dist/scripts/updateContractInfo",
+      "runtimeExecutable": "doppler",
+      "runtimeArgs": [
+        "run",
+        "--",
+        "node",
+        "${workspaceFolder}/dist/scripts/updateContractInfo"
+      ],
+      "preLaunchTask": "tsc: watch - tsconfig.json",
+      "outFiles": ["${workspaceFolder}/dist/**/*.js"],
+      "outputCapture": "std",
+      "internalConsoleOptions": "openOnSessionStart",
+      "args": ["0x1036a545d8dC68B2372E0F85810A4539399B0D7A"]
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Queue Contract Info",
+      "program": "${workspaceFolder}/dist/scripts/queueUpdateContractInfo",
+      "runtimeExecutable": "doppler",
+      "runtimeArgs": [
+        "run",
+        "--",
+        "node",
+        "${workspaceFolder}/dist/scripts/queueUpdateContractInfo"
+      ],
+      "preLaunchTask": "tsc: watch - tsconfig.json",
+      "outFiles": ["${workspaceFolder}/dist/**/*.js"],
+      "outputCapture": "std",
+      "internalConsoleOptions": "openOnSessionStart",
+      "args": ["100000", "true"]
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Launch Contract Info Server",
+      "program": "${workspaceFolder}/dist/contractInfoServer",
+      "runtimeExecutable": "doppler",
+      "runtimeArgs": [
+        "run",
+        "--",
+        "node",
+        "${workspaceFolder}/dist/contractInfoServer"
+      ],
+      "preLaunchTask": "tsc: watch - tsconfig.json",
+      "outFiles": ["${workspaceFolder}/dist/**/*.js"],
+      "outputCapture": "std",
+      "internalConsoleOptions": "openOnSessionStart"
+    },
+    {
+      "type": "node",
+      "request": "launch",
       "name": "jest-test-current-file",
       "runtimeExecutable": "doppler",
       "runtimeArgs": [

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -72,7 +72,7 @@
       "outFiles": ["${workspaceFolder}/dist/**/*.js"],
       "outputCapture": "std",
       "internalConsoleOptions": "openOnSessionStart",
-      "args": ["100000", "true"]
+      "args": ["100000"]
     },
     {
       "type": "node",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -54,7 +54,7 @@
       "outFiles": ["${workspaceFolder}/dist/**/*.js"],
       "outputCapture": "std",
       "internalConsoleOptions": "openOnSessionStart",
-      "args": ["0x1036a545d8dC68B2372E0F85810A4539399B0D7A", "5832978"]
+      "args": ["0x1036a545d8dC68B2372E0F85810A4539399B0D7A"]
     },
     {
       "type": "node",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -54,7 +54,7 @@
       "outFiles": ["${workspaceFolder}/dist/**/*.js"],
       "outputCapture": "std",
       "internalConsoleOptions": "openOnSessionStart",
-      "args": ["0x1036a545d8dC68B2372E0F85810A4539399B0D7A"]
+      "args": ["0x1036a545d8dC68B2372E0F85810A4539399B0D7A", "5832978"]
     },
     {
       "type": "node",

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@upstreamapp/fortuna",
-  "version": "0.0.37-0",
+  "version": "0.0.38-0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@upstreamapp/fortuna",
-      "version": "0.0.37-0",
+      "version": "0.0.38-0",
       "license": "ISC",
       "dependencies": {
         "axios": "^0.27.2"

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@upstreamapp/fortuna",
-  "version": "0.0.38-0",
+  "version": "0.0.37-0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@upstreamapp/fortuna",
-      "version": "0.0.38-0",
+      "version": "0.0.37-0",
       "license": "ISC",
       "dependencies": {
         "axios": "^0.27.2"

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@upstreamapp/fortuna",
-  "version": "0.0.38-0",
+  "version": "0.0.37-0",
   "description": "Your best source of tokens in an address",
   "main": "./client/index.js",
   "types": "./client/index.d.ts",

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@upstreamapp/fortuna",
-  "version": "0.0.37-0",
+  "version": "0.0.38-0",
   "description": "Your best source of tokens in an address",
   "main": "./client/index.js",
   "types": "./client/index.d.ts",

--- a/fortuna-charts/fortuna-goerli-chart/templates/deployment.yaml
+++ b/fortuna-charts/fortuna-goerli-chart/templates/deployment.yaml
@@ -37,3 +37,9 @@ spec:
           envFrom:
             - secretRef:
                 name: {{ .Values.deployment.secrets.envFrom }}
+        - name: fortuna-token
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          command: ['node', 'dist/contractInfoServer.js']
+          envFrom:
+            - secretRef:
+                name: {{ .Values.deployment.secrets.envFrom }}

--- a/fortuna-charts/fortuna-goerli-chart/templates/deployment.yaml
+++ b/fortuna-charts/fortuna-goerli-chart/templates/deployment.yaml
@@ -37,7 +37,7 @@ spec:
           envFrom:
             - secretRef:
                 name: {{ .Values.deployment.secrets.envFrom }}
-        - name: fortuna-token
+        - name: fortuna-contract-info
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           command: ['node', 'dist/contractInfoServer.js']
           envFrom:

--- a/fortuna-charts/fortuna-goerli-chart/values.yaml
+++ b/fortuna-charts/fortuna-goerli-chart/values.yaml
@@ -2,7 +2,7 @@ replicaCount: 1
 
 image:
   repository: 706936537074.dkr.ecr.us-west-2.amazonaws.com/upstreamapp/fortuna
-  tag: ~HASH~
+  tag: sha-~HASH~
   pullPolicy: IfNotPresent
 
 service:

--- a/fortuna-charts/fortuna-mainnet-chart/templates/deployment.yaml
+++ b/fortuna-charts/fortuna-mainnet-chart/templates/deployment.yaml
@@ -37,3 +37,9 @@ spec:
           envFrom:
             - secretRef:
                 name: {{ .Values.deployment.secrets.envFrom }}
+        - name: fortuna-contract-info
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          command: ['node', 'dist/contractInfoServer.js']
+          envFrom:
+            - secretRef:
+                name: {{ .Values.deployment.secrets.envFrom }}

--- a/fortuna-charts/fortuna-mainnet-chart/values.yaml
+++ b/fortuna-charts/fortuna-mainnet-chart/values.yaml
@@ -2,7 +2,7 @@ replicaCount: 1
 
 image:
   repository: 706936537074.dkr.ecr.us-west-2.amazonaws.com/upstreamapp/fortuna
-  tag: ~HASH~
+  tag: sha-~HASH~
   pullPolicy: IfNotPresent
 
 service:

--- a/jest.config.js
+++ b/jest.config.js
@@ -6,7 +6,9 @@ module.exports = {
   testTimeout: 20000,
   moduleNameMapper: {
     '^@utils(.*)$': '<rootDir>/src/utils$1',
-    '^@models(.*)$': '<rootDir>/src/models$1'
+    '^@models(.*)$': '<rootDir>/src/models$1',
+    '^@lib(.*)$': '<rootDir>/src/lib$1',
+    '^@types(.*)$': '<rootDir>/src/@types$1'
   },
   testRegex: '.test.(ts|js)$',
   rootDir: '.',

--- a/package.json
+++ b/package.json
@@ -10,9 +10,11 @@
     "monitoring": "node dist/monitoringServer.js",
     "querying": "node dist/queryingServer.js",
     "tokenInfo": "node dist/tokenInfoServer.js",
+    "contractInfo": "node dist/contractInfoServer.js",
     "start:monitoring": "doppler run -- npm run monitoring",
     "start:querying": "doppler run -- npm run querying",
     "start:tokenInfo": "doppler run -- npm run tokenInfo",
+    "start:contractInfo": "doppler run -- npm run contractInfo",
     "codegen:build": "tsc --esModuleInterop codegen/**/generator.ts",
     "migration:create": "npm run codegen:build && node codegen/migration/generator.js",
     "migration:up": "sequelize-cli db:migrate",
@@ -69,7 +71,9 @@
   },
   "_moduleAliases": {
     "@models": "dist/models",
-    "@utils": "dist/utils"
+    "@utils": "dist/utils",
+    "@lib": "dist/lib",
+    "@types": "dist/@types"
   },
   "repository": {
     "type": "git",

--- a/src/@types/index.ts
+++ b/src/@types/index.ts
@@ -24,6 +24,8 @@ export interface ITokenInfo {
     name: Maybe<string>
     symbol: Maybe<string>
     decimals: Maybe<number>
+    ethBalance: Maybe<BigInt>
+    lastTransactionDate: Maybe<Date>
   }
   token: {
     id: Maybe<string>

--- a/src/@types/index.ts
+++ b/src/@types/index.ts
@@ -101,3 +101,8 @@ export type TotalTokenValue = {
   balance: string
   token_ids: string[]
 }
+
+export enum ProcessingGoal {
+  BACKFILL,
+  REALTIME
+}

--- a/src/contractInfoServer.ts
+++ b/src/contractInfoServer.ts
@@ -7,6 +7,7 @@ import cluster from 'cluster'
 import { cpus } from 'os'
 import { Consumer } from 'sqs-consumer'
 import {
+  CONTRACT_INFO_CLUSTER_MODE,
   CONTRACT_INFO_QUEUE_BATCH,
   CONTRACT_INFO_QUEUE_URL
 } from './lib/constants'
@@ -48,7 +49,7 @@ async function consumeQueue(): Promise<undefined> {
 }
 
 // spreading the workload of consuming the queue jobs
-if (cluster.isPrimary && CONTRACT_INFO_QUEUE_URL) {
+if (cluster.isPrimary && CONTRACT_INFO_CLUSTER_MODE) {
   logger.info(`Primary thread; Spinning up ${coreCount} workers...`)
 
   for (var i = 0; i < coreCount - 1; i++) {

--- a/src/contractInfoServer.ts
+++ b/src/contractInfoServer.ts
@@ -1,20 +1,24 @@
+import 'dotenv/config'
+import 'module-alias/register'
+import 'source-map-support/register'
+
 import './lib/doom'
 import cluster from 'cluster'
 import { cpus } from 'os'
 import { Consumer } from 'sqs-consumer'
 import {
-  TOKEN_INFO_BATCH,
-  TOKEN_INFO_CLUSTER_MODE,
-  TOKEN_INFO_QUEUE_URL
+  CONTRACT_INFO_QUEUE_BATCH,
+  CONTRACT_INFO_QUEUE_URL
 } from './lib/constants'
 import Logger from './lib/logger'
-import { ITokenInfoJobDetails } from './lib/queueTokenInfoJobs'
-import updateTokenInfo from './lib/updateTokenInfo'
+import { IContractInfoJobDetails } from './lib/queueContractInfoJobs'
+import updateContractInfo from './lib/updateContractInfo'
+
 const logger = Logger(module)
 const coreCount = cpus().length
 
 /**
- * Consume the TokenInfo queue.
+ * Consume the ContractInfo queue.
  *
  * @remarks
  * The queue that is being consumed gets its jobs from the `monitoringServer` and `queryingServer`.
@@ -22,32 +26,32 @@ const coreCount = cpus().length
  * @returns {Promise<undefined>} This function does not return any useful value.
  */
 async function consumeQueue(): Promise<undefined> {
-  if (!TOKEN_INFO_QUEUE_URL) {
+  if (!CONTRACT_INFO_QUEUE_URL) {
     logger.warn('Invalid value given to `SQS_URL`')
     return process.exit(1)
   }
 
   const app = new Consumer({
-    batchSize: TOKEN_INFO_BATCH,
-    queueUrl: TOKEN_INFO_QUEUE_URL,
+    batchSize: CONTRACT_INFO_QUEUE_BATCH, //TODO different batch size
+    queueUrl: CONTRACT_INFO_QUEUE_URL,
     handleMessage: async sqsMessage => {
-      const data: ITokenInfoJobDetails = JSON.parse(sqsMessage.Body!)
-      await updateTokenInfo(data.tokenAddress, data.tokenId)
+      const data: IContractInfoJobDetails = JSON.parse(sqsMessage.Body!)
+      await updateContractInfo(data)
     }
   })
 
   app.on('error', err => logger.error(err.message))
   app.on('processing_error', err => logger.error(err.message))
 
-  logger.info(`Starting token info update queue consumer...`)
+  logger.info(`Starting contract info update queue consumer...`)
   app.start()
 }
 
 // spreading the workload of consuming the queue jobs
-if (cluster.isPrimary && TOKEN_INFO_CLUSTER_MODE) {
+if (cluster.isPrimary && CONTRACT_INFO_QUEUE_URL) {
   logger.info(`Primary thread; Spinning up ${coreCount} workers...`)
 
-  for (var i = 0; i < coreCount; i++) {
+  for (var i = 0; i < coreCount - 1; i++) {
     cluster.fork()
   }
 

--- a/src/db/operations/enrichBalances.ts
+++ b/src/db/operations/enrichBalances.ts
@@ -3,12 +3,8 @@ import { IBalance, IEnrichedBalance, ITokenInfo } from '../../@types'
 import queueTokenInfoJobs, {
   ITokenInfoJobDetails
 } from '../../lib/queueTokenInfoJobs'
-import { TokenInfo } from '../../models/TokenInfo/TokenInfo'
-import {
-  queueContractInfoByTokenAddressJobs,
-  IContractInfoJobDetailsByTokenAddress
-} from '@lib/queueContractInfoJobs'
-import { ContractInfo } from '@models/index'
+import { IContractInfoJobDetailsByTokenAddress } from '@lib/queueContractInfoJobs'
+import { ContractInfo, TokenInfo } from '@models/index'
 
 /**
  * Map an instance of `TokenInfo` into `ITokenInfo`.
@@ -89,7 +85,6 @@ async function enrichBalances(
       tokenAddress: missingToken.tokenAddress,
       tokenId: missingToken.tokenId
     }))
-    await queueContractInfoByTokenAddressJobs(jobDetails)
     await queueTokenInfoJobs(jobDetails)
   }
 

--- a/src/db/operations/enrichBalances.ts
+++ b/src/db/operations/enrichBalances.ts
@@ -1,7 +1,13 @@
 import { Op } from 'sequelize'
 import { IBalance, IEnrichedBalance, ITokenInfo } from '../../@types'
-import queueTokenInfoJobs from '../../lib/queueTokenInfoJobs'
+import queueTokenInfoJobs, {
+  ITokenInfoJobDetails
+} from '../../lib/queueTokenInfoJobs'
 import { TokenInfo } from '../../models/TokenInfo/TokenInfo'
+import queueContractInfoJobs, {
+  IContractInfoJobDetails
+} from '@lib/queueContractInfoJobs'
+import { ContractInfo } from '@models/index'
 
 /**
  * Map an instance of `TokenInfo` into `ITokenInfo`.
@@ -18,10 +24,10 @@ function tokenInfoMapper(tokenInfo: Maybe<TokenInfo>): Maybe<ITokenInfo> {
   return {
     contract: {
       address: tokenInfo.address,
-      type: tokenInfo.tokenType,
-      name: tokenInfo.contractName,
-      symbol: tokenInfo.symbol,
-      decimals: tokenInfo.decimals
+      type: tokenInfo.contractInfo.tokenType,
+      name: tokenInfo.contractInfo.name,
+      symbol: tokenInfo.contractInfo.symbol,
+      decimals: tokenInfo.contractInfo.decimals
     },
     token: {
       id: tokenInfo.tokenId,
@@ -58,7 +64,8 @@ async function enrichBalances(
         address: balance.tokenAddress,
         tokenId: balance.tokenId ?? null
       }))
-    }
+    },
+    include: [{ model: ContractInfo, as: 'contractInfo' }]
   })
 
   // add tokens that have been indexed but that have not had their metadata extracted, into the queue for extraction by the tokenInfoServer.
@@ -72,12 +79,13 @@ async function enrichBalances(
         )
     )
 
-    await queueTokenInfoJobs(
+    const jobDetails: (IContractInfoJobDetails | ITokenInfoJobDetails)[] =
       missingTokens.map(missingToken => ({
         tokenAddress: missingToken.tokenAddress,
         tokenId: missingToken.tokenId
       }))
-    )
+    await queueContractInfoJobs(jobDetails)
+    await queueTokenInfoJobs(jobDetails)
   }
 
   return balances.map(balance => ({

--- a/src/db/operations/enrichBalances.ts
+++ b/src/db/operations/enrichBalances.ts
@@ -4,8 +4,9 @@ import queueTokenInfoJobs, {
   ITokenInfoJobDetails
 } from '../../lib/queueTokenInfoJobs'
 import { TokenInfo } from '../../models/TokenInfo/TokenInfo'
-import queueContractInfoJobs, {
-  IContractInfoJobDetails
+import {
+  queueContractInfoByTokenAddressJobs,
+  IContractInfoJobDetailsByTokenAddress
 } from '@lib/queueContractInfoJobs'
 import { ContractInfo } from '@models/index'
 
@@ -81,12 +82,14 @@ async function enrichBalances(
         )
     )
 
-    const jobDetails: (IContractInfoJobDetails | ITokenInfoJobDetails)[] =
-      missingTokens.map(missingToken => ({
-        tokenAddress: missingToken.tokenAddress,
-        tokenId: missingToken.tokenId
-      }))
-    await queueContractInfoJobs(jobDetails)
+    const jobDetails: (
+      | IContractInfoJobDetailsByTokenAddress
+      | ITokenInfoJobDetails
+    )[] = missingTokens.map(missingToken => ({
+      tokenAddress: missingToken.tokenAddress,
+      tokenId: missingToken.tokenId
+    }))
+    await queueContractInfoByTokenAddressJobs(jobDetails)
     await queueTokenInfoJobs(jobDetails)
   }
 

--- a/src/db/operations/enrichBalances.ts
+++ b/src/db/operations/enrichBalances.ts
@@ -27,7 +27,9 @@ function tokenInfoMapper(tokenInfo: Maybe<TokenInfo>): Maybe<ITokenInfo> {
       type: tokenInfo.contractInfo.tokenType,
       name: tokenInfo.contractInfo.name,
       symbol: tokenInfo.contractInfo.symbol,
-      decimals: tokenInfo.contractInfo.decimals
+      decimals: tokenInfo.contractInfo.decimals,
+      ethBalance: tokenInfo.contractInfo.ethBalance,
+      lastTransactionDate: tokenInfo.contractInfo.lastTransactionAt
     },
     token: {
       id: tokenInfo.tokenId,

--- a/src/db/operations/enrichBalances.ts
+++ b/src/db/operations/enrichBalances.ts
@@ -3,8 +3,12 @@ import { IBalance, IEnrichedBalance, ITokenInfo } from '../../@types'
 import queueTokenInfoJobs, {
   ITokenInfoJobDetails
 } from '../../lib/queueTokenInfoJobs'
-import { IContractInfoJobDetailsByTokenAddress } from '@lib/queueContractInfoJobs'
-import { ContractInfo, TokenInfo } from '@models/index'
+import { TokenInfo } from '../../models/TokenInfo/TokenInfo'
+import {
+  queueContractInfoByTokenAddressJobs,
+  IContractInfoJobDetailsByTokenAddress
+} from '@lib/queueContractInfoJobs'
+import { ContractInfo } from '@models/index'
 
 /**
  * Map an instance of `TokenInfo` into `ITokenInfo`.
@@ -85,6 +89,7 @@ async function enrichBalances(
       tokenAddress: missingToken.tokenAddress,
       tokenId: missingToken.tokenId
     }))
+    await queueContractInfoByTokenAddressJobs(jobDetails)
     await queueTokenInfoJobs(jobDetails)
   }
 

--- a/src/lib/backfillProcessing.ts
+++ b/src/lib/backfillProcessing.ts
@@ -1,7 +1,7 @@
-import { SyncingState } from '../@types'
+import { ProcessingGoal, SyncingState } from '../@types'
 import updateSyncingState from '../db/operations/statusTable/updateSyncingState'
 import Logger from './logger'
-import processBlocks, { ProcessingGoal } from './processBlocks'
+import processBlocks from './processBlocks'
 
 const logger = Logger(module)
 

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -13,21 +13,26 @@ export const GOERLI_RPC_PROVIDER_URL = process.env.GOERLI_RPC_PROVIDER_URL
 export const GENESIS = 0
 export const MAINNET_FIRST_TRANSFER_BLOCK = 447767
 export const GOERLI_FIRST_TRANSFER_BLOCK = 13475
-export const REALTIME_BATCH = Number(process.env.REALTIME_BATCH) || 1
-export const REALTIME_PARALLEL_QUERIES =
-  Number(process.env.REALTIME_PARALLEL_QUERIES) || 1
-export const BACKFILL_BATCH = Number(process.env.BACKFILL_BATCH) || 10
-export const BACKFILL_PARALLEL_QUERIES =
-  Number(process.env.BACKFILL_PARALLEL_QUERIES) || 25
+export const REALTIME_BATCH = Number(process.env.REALTIME_BATCH || 1)
+export const REALTIME_PARALLEL_QUERIES = Number(
+  process.env.REALTIME_PARALLEL_QUERIES || 1
+)
+export const BACKFILL_BATCH = Number(process.env.BACKFILL_BATCH || 10)
+export const BACKFILL_PARALLEL_QUERIES = Number(
+  process.env.BACKFILL_PARALLEL_QUERIES || 25
+)
 export const REALTIME_START_REPEAT = 5
 export const ETH_NETWORK = process.env.ETH_NETWORK
 export const DATABASE_CONNECTION_STRING = `${process.env.DATABASE_URL}/${process.env.ETH_NETWORK}`
 export const TOKEN_INFO_MAX_AGE_IN_DAYS = 1
+export const CONTRACT_INFO_MAX_AGE_IN_DAYS = 1
 export const BLACKHOLE = `0x0000000000000000000000000000000000000001`
-export const QUEUE_URL = process.env.SQS_URL
-export const TOKEN_INFO_BATCH = process.env.TOKEN_INFO_BATCH
-  ? Number(process.env.TOKEN_INFO_BATCH)
-  : 1
+export const CONTRACT_INFO_QUEUE_URL = process.env.SQS_CONTRACT_INFO_URL
+export const TOKEN_INFO_QUEUE_URL = process.env.SQS_TOKEN_INFO_URL
+export const CONTRACT_INFO_QUEUE_BATCH = Number(
+  process.env.CONTRACT_INFO_QUEUE_BATCH || 1
+)
+export const TOKEN_INFO_BATCH = Number(process.env.TOKEN_INFO_BATCH || 1)
 export const TOKEN_INFO_CLUSTER_MODE =
   process.env.TOKEN_INFO_CLUSTER_MODE === 'true'
 export const NUM_OF_BLOCKS_TO_REPROCESS = 1

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -24,17 +24,25 @@ export const BACKFILL_PARALLEL_QUERIES = Number(
 export const REALTIME_START_REPEAT = 5
 export const ETH_NETWORK = process.env.ETH_NETWORK
 export const DATABASE_CONNECTION_STRING = `${process.env.DATABASE_URL}/${process.env.ETH_NETWORK}`
-export const TOKEN_INFO_MAX_AGE_IN_DAYS = 1
-export const CONTRACT_INFO_MAX_AGE_IN_DAYS = 1
+
 export const BLACKHOLE = `0x0000000000000000000000000000000000000001`
+
+// contract info
+export const CONTRACT_INFO_MAX_AGE_IN_DAYS = 1
 export const CONTRACT_INFO_QUEUE_URL = process.env.SQS_CONTRACT_INFO_URL
-export const TOKEN_INFO_QUEUE_URL = process.env.SQS_TOKEN_INFO_URL
 export const CONTRACT_INFO_QUEUE_BATCH = Number(
   process.env.CONTRACT_INFO_QUEUE_BATCH || 1
 )
+export const CONTRACT_INFO_CLUSTER_MODE =
+  process.env.CONTRACT_INFO_CLUSTER_MODE === 'true'
+
+// token info
+export const TOKEN_INFO_MAX_AGE_IN_DAYS = 1
+export const TOKEN_INFO_QUEUE_URL = process.env.SQS_TOKEN_INFO_URL
 export const TOKEN_INFO_BATCH = Number(process.env.TOKEN_INFO_BATCH || 1)
 export const TOKEN_INFO_CLUSTER_MODE =
   process.env.TOKEN_INFO_CLUSTER_MODE === 'true'
+
 export const NUM_OF_BLOCKS_TO_REPROCESS = 1
 export const LOG_LEVEL = process.env.LOG_LEVEL
 export const SQL_DEBUG = process.env.SQL_DEBUG

--- a/src/lib/processBlocks.ts
+++ b/src/lib/processBlocks.ts
@@ -1,5 +1,5 @@
 import Bluebird from 'bluebird'
-import { chunk, uniqBy } from 'lodash'
+import { chunk } from 'lodash'
 import { format } from 'node-pg-format'
 import { ProcessingGoal, TokenType } from '../@types'
 import { abi } from '../common/abi'
@@ -18,13 +18,12 @@ import getLogs from './getLogs'
 import Logger from './logger'
 import parseLog from './parseLog'
 import {
-  queueUpdateExistingContractInfoByBlock,
-  IContractInfoJobDetailsByBlock,
-  queueAllContractInfoRecords
+  queueContractInfoByTokenAddressJobs,
+  queueUpdateExistingContractInfoByBlockJobs,
+  IContractInfoJobDetailsByTokenAddress,
+  IContractInfoJobDetailsByBlock
 } from './queueContractInfoJobs'
-import queueUpdateTokenInfo, {
-  ITokenInfoJobDetails
-} from './queueTokenInfoJobs'
+import queueTokenInfoJobs, { ITokenInfoJobDetails } from './queueTokenInfoJobs'
 import stats from './stats'
 
 type FormattedTransaction = {
@@ -150,18 +149,34 @@ export default async function processBlocks(
 
       // queue each token that has been transferred so that the tokenInfoServer can extract their metadata.
 
+      const tokenContractJobDetails: Array<
+        IContractInfoJobDetailsByTokenAddress | ITokenInfoJobDetails
+      > = formattedTransactions.map(tx => ({
+        tokenAddress: tx.address,
+        tokenId: tx.tokenId,
+        transferBlockNumber: tx.blockNumber,
+        goal
+      }))
+      await queueContractInfoByTokenAddressJobs(tokenContractJobDetails)
+      await queueTokenInfoJobs(tokenContractJobDetails)
+
       stats.gauge(`insert_batch_size`, formattedTransactions.length)
 
-      const tokenContractJobDetails: Array<ITokenInfoJobDetails> =
-        formattedTransactions.map(tx => ({
-          tokenAddress: tx.address,
-          tokenId: tx.tokenId
-        }))
+      const dbDateStart = Date.now()
 
-      await createNewContractInfoRecords(tokenContractJobDetails)
-      // await await queueUpdateContractInfoByTokenAddress(tokenContractJobDetails) // satisfies new contracts during backfill (early rejection on duplicate) and realtime
-      await queueUpdateTokenInfo(tokenContractJobDetails)
-      await createTokenTransferRecords(formattedTransactions)
+      // insert each token transfer into the TokenTransfer table if it doesn't already exist. If it exists, skip it.
+      await Bluebird.Promise.mapSeries(
+        chunk(formattedTransactions.map(Object.values), 1000),
+        txsChunk =>
+          sequelize.query(
+            format(
+              `INSERT INTO "TokenTransfer" ("tokenType", "tokenAddress", "fromAddress", "toAddress", "operator", "tokenId", "value", "transactionHash", "logIndex", "blockNumber") VALUES %L ON CONFLICT DO NOTHING;`,
+              txsChunk
+            )
+          )
+      )
+      const dbDateEnd = Date.now() - dbDateStart
+      stats.histogram(`submit_transactions_to_db`, dbDateEnd)
 
       const highestBlock = formattedTransactions.at(-1)?.blockNumber
       if (highestBlock) {
@@ -181,59 +196,16 @@ export default async function processBlocks(
   }
 
   if (goalIsBackfill) {
-    await queueAllContractInfoRecords()
     return
   }
 
-  // Update existing ERC20, ERC721, ERC1155 contracts on any new block that might also not be transfer events above
+  // Update existing ERC20, ERC721, ERC1155 contracts on any new block that might also not be transfer events
   const blockContractJobDetails: IContractInfoJobDetailsByBlock[] = []
   for (let block = fromBlock; block <= toBlock; block++) {
     blockContractJobDetails.push({
-      blockNumber: block
+      blockNumber: block,
+      goal
     })
   }
-  await queueUpdateExistingContractInfoByBlock(blockContractJobDetails)
-}
-
-async function createNewContractInfoRecords(
-  tokens: { tokenAddress: string }[]
-) {
-  const dateStart = Date.now()
-  // insert each token transfer into the TokenTransfer table if it doesn't already exist. If it exists, skip it.
-  await Bluebird.Promise.mapSeries(
-    chunk(
-      uniqBy(tokens, token => token.tokenAddress).map(token => [
-        token.tokenAddress
-      ]),
-      1000
-    ),
-    tokenChunk =>
-      sequelize.query(
-        format(
-          `INSERT INTO "ContractInfo" ("address") VALUES %L ON CONFLICT DO NOTHING;`,
-          tokenChunk
-        )
-      )
-  )
-  const dateEndDif = Date.now() - dateStart
-  stats.histogram(`submit_contractInfo_transactions_to_db`, dateEndDif)
-}
-
-async function createTokenTransferRecords(
-  formattedTransactions: FormattedTransaction[]
-) {
-  const dateStart = Date.now()
-  // insert each token transfer into the TokenTransfer table if it doesn't already exist. If it exists, skip it.
-  await Bluebird.Promise.mapSeries(
-    chunk(formattedTransactions.map(Object.values), 1000),
-    txsChunk =>
-      sequelize.query(
-        format(
-          `INSERT INTO "TokenTransfer" ("tokenType", "tokenAddress", "fromAddress", "toAddress", "operator", "tokenId", "value", "transactionHash", "logIndex", "blockNumber") VALUES %L ON CONFLICT DO NOTHING;`,
-          txsChunk
-        )
-      )
-  )
-  const dateEndDif = Date.now() - dateStart
-  stats.histogram(`submit_transactions_to_db`, dateEndDif)
+  await queueUpdateExistingContractInfoByBlockJobs(blockContractJobDetails)
 }

--- a/src/lib/processBlocks.ts
+++ b/src/lib/processBlocks.ts
@@ -152,7 +152,7 @@ export default async function processBlocks(
       > = formattedTransactions.map(tx => ({
         tokenAddress: tx.address,
         tokenId: tx.tokenId,
-        blockNumber: tx.blockNumber,
+        transferBlockNumber: tx.blockNumber,
         goal
       }))
       await queueContractInfoByTokenAddressJobs(tokenContractJobDetails)

--- a/src/lib/processBlocks.ts
+++ b/src/lib/processBlocks.ts
@@ -67,10 +67,12 @@ export default async function processBlocks(
   await updateSyncing(true)
 
   try {
-    while (fromBlock <= toBlock) {
-      const displayFrom = fromBlock
+    let processFrom = fromBlock
+
+    while (processFrom <= toBlock) {
+      const displayFrom = processFrom
       const displayTo =
-        fromBlock + parallelQueries * batch + parallelQueries - 1
+        processFrom + parallelQueries * batch + parallelQueries - 1
 
       await updateSyncingBlocks([displayFrom, displayTo])
 
@@ -79,8 +81,8 @@ export default async function processBlocks(
       // fetch transaction logs and parallelizing the queries to spread the load
       const logs = Array.from(Array(parallelQueries).keys()).map(() => {
         // batch each query by a certain number of blocks
-        const logPromises = getLogs(fromBlock, fromBlock + batch)
-        fromBlock = fromBlock + batch + 1
+        const logPromises = getLogs(processFrom, processFrom + batch)
+        processFrom = processFrom + batch + 1
         return logPromises
       })
 
@@ -199,7 +201,7 @@ export default async function processBlocks(
 
   // Update existing ERC20, ERC721, ERC1155 contracts on any new block that might also not be transfer events
   const blockContractJobDetails: IContractInfoJobDetailsByBlock[] = []
-  for (let block = fromBlock; block < toBlock; block++) {
+  for (let block = fromBlock; block <= toBlock; block++) {
     blockContractJobDetails.push({
       blockNumber: block,
       goal

--- a/src/lib/processBlocks.ts
+++ b/src/lib/processBlocks.ts
@@ -67,12 +67,12 @@ export default async function processBlocks(
   await updateSyncing(true)
 
   try {
-    let processFrom = fromBlock
+    let fromBlockStart = fromBlock
 
-    while (processFrom <= toBlock) {
-      const displayFrom = processFrom
+    while (fromBlockStart <= toBlock) {
+      const displayFrom = fromBlockStart
       const displayTo =
-        processFrom + parallelQueries * batch + parallelQueries - 1
+        fromBlockStart + parallelQueries * batch + parallelQueries - 1
 
       await updateSyncingBlocks([displayFrom, displayTo])
 
@@ -81,8 +81,8 @@ export default async function processBlocks(
       // fetch transaction logs and parallelizing the queries to spread the load
       const logs = Array.from(Array(parallelQueries).keys()).map(() => {
         // batch each query by a certain number of blocks
-        const logPromises = getLogs(processFrom, processFrom + batch)
-        processFrom = processFrom + batch + 1
+        const logPromises = getLogs(fromBlockStart, fromBlockStart + batch)
+        fromBlockStart = fromBlockStart + batch + 1
         return logPromises
       })
 

--- a/src/lib/queueContractInfoJobs.ts
+++ b/src/lib/queueContractInfoJobs.ts
@@ -43,7 +43,7 @@ export async function queueContractInfoBackfill({
             : {}),
           ...(unproccessedOnly
             ? {
-                lastTransferBlock: { [Op.is]: null }
+                lastTransactionBlock: { [Op.is]: null }
               }
             : undefined)
         }

--- a/src/lib/queueContractInfoJobs.ts
+++ b/src/lib/queueContractInfoJobs.ts
@@ -48,7 +48,7 @@ export async function queueContractInfoBackfill({
             : {}),
           ...(unproccessedOnly
             ? {
-                ethBalance: { [Op.is]: null }
+                lastTransactionBlock: { [Op.is]: null }
               }
             : undefined)
         }

--- a/src/lib/queueContractInfoJobs.ts
+++ b/src/lib/queueContractInfoJobs.ts
@@ -43,7 +43,7 @@ export async function queueContractInfoBackfill({
             : {}),
           ...(unproccessedOnly
             ? {
-                lastTransactionBlock: { [Op.is]: null }
+                ethBalance: { [Op.is]: null }
               }
             : undefined)
         }

--- a/src/lib/queueContractInfoJobs.ts
+++ b/src/lib/queueContractInfoJobs.ts
@@ -1,11 +1,9 @@
 import SQS from 'aws-sdk/clients/sqs'
 import Bluebird from 'bluebird'
 import { chunk, orderBy, uniqBy } from 'lodash'
-import { Op } from 'sequelize'
 import { CONTRACT_INFO_QUEUE_URL } from './constants'
 import Logger from './logger'
 import stats from './stats'
-import { ContractInfo } from '@models/index'
 import { ProcessingGoal } from '@types'
 
 const logger = Logger(module)
@@ -29,43 +27,6 @@ export type TBackfill = {
   howMany?: number
   unproccessedOnly?: boolean
   minId?: number
-}
-
-export async function queueContractInfoBackfill({
-  howMany,
-  unproccessedOnly = true,
-  minId
-}: TBackfill) {
-  const whereClause =
-    minId || unproccessedOnly
-      ? {
-          ...(minId
-            ? {
-                id: {
-                  [Op.gte]: minId
-                }
-              }
-            : {}),
-          ...(unproccessedOnly
-            ? {
-                lastTransactionBlock: { [Op.is]: null }
-              }
-            : undefined)
-        }
-      : undefined
-
-  const contracts = await ContractInfo.findAll({
-    where: whereClause,
-    limit: howMany ? +howMany : undefined,
-    order: [['id', 'asc']]
-  })
-
-  const queueTokens: IContractInfoJobDetailsByTokenAddress[] = contracts.map(
-    contract => ({
-      tokenAddress: contract.address
-    })
-  )
-  await queueContractInfoByTokenAddressJobs(queueTokens)
 }
 
 /**

--- a/src/lib/queueContractInfoJobs.ts
+++ b/src/lib/queueContractInfoJobs.ts
@@ -1,0 +1,112 @@
+import SQS from 'aws-sdk/clients/sqs'
+import Bluebird from 'bluebird'
+import { chunk, orderBy, uniqBy } from 'lodash'
+import { Op } from 'sequelize'
+import { CONTRACT_INFO_QUEUE_URL } from './constants'
+import Logger from './logger'
+import stats from './stats'
+import { ContractInfo } from '@models/index'
+import { ProcessingGoal } from '@types'
+
+const logger = Logger(module)
+const sqs = new SQS({
+  apiVersion: 'latest'
+})
+
+export interface IContractInfoJobDetails {
+  tokenAddress: string
+  blockNumber?: number
+  goal?: ProcessingGoal
+  full?: boolean
+}
+
+export type TBackfill = {
+  howMany?: number
+  unproccessedOnly?: boolean
+  minId?: number
+}
+
+export async function queueContractInfoBackfill({
+  howMany,
+  unproccessedOnly = true,
+  minId
+}: TBackfill) {
+  const whereClause =
+    minId || unproccessedOnly
+      ? {
+          ...(minId
+            ? {
+                id: {
+                  [Op.gte]: minId
+                }
+              }
+            : {}),
+          ...(unproccessedOnly
+            ? {
+                lastTransferBlock: { [Op.is]: null }
+              }
+            : undefined)
+        }
+      : undefined
+
+  const contracts = await ContractInfo.findAll({
+    where: whereClause,
+    limit: howMany ? +howMany : undefined,
+    order: [['id', 'asc']]
+  })
+
+  const queueTokens: IContractInfoJobDetails[] = contracts.map(contract => ({
+    tokenAddress: contract.address
+  }))
+
+  await queueContractInfoJobs(queueTokens)
+}
+
+/**
+ * Add token contracts into the queue for further processing.
+ *
+ * @remarks
+ * The queue where these tokens get added to is consumed by the contractInfoServer.
+ *
+ * @param {tokens} tokens - The tokens whose contract needs to be added into the queue for metadata extraction by the contractInfoServer.
+ *
+ * @returns {Promise<boolean>} `Promise<boolean>` - A boolean indicating whether the tokens have been added to the queue successfully or not.
+ */
+async function queueContractInfoJobs(
+  tokens: IContractInfoJobDetails[]
+): Promise<boolean> {
+  try {
+    if (!CONTRACT_INFO_QUEUE_URL || !tokens.length) {
+      return false
+    }
+
+    stats.increment('contract_token_info_job', tokens.length)
+
+    // there's no need to add the same contract into the queue during every round of block(s) processing. only pick latest once
+    const uniqueTokens = uniqBy(
+      orderBy(tokens, ['blockNumber'], ['desc']),
+      token => token.tokenAddress
+    )
+    await Bluebird.Promise.map(
+      chunk(uniqueTokens, 10),
+      chunk =>
+        sqs
+          .sendMessageBatch({
+            QueueUrl: CONTRACT_INFO_QUEUE_URL!,
+            Entries: chunk.map(data => ({
+              Id: `contractInfo-token-${data.tokenAddress}`,
+              MessageBody: JSON.stringify(data)
+            }))
+          })
+          .promise(),
+      { concurrency: 10 }
+    )
+
+    return true
+  } catch (err) {
+    logger.warn(`Failed at queueTokenInfoJob: ${err}`)
+    return false
+  }
+}
+
+export default queueContractInfoJobs

--- a/src/lib/queueTokenInfoJobs.ts
+++ b/src/lib/queueTokenInfoJobs.ts
@@ -25,7 +25,7 @@ export interface ITokenInfoJobDetails {
  *
  * @returns {Promise<boolean>} `Promise<boolean>` - A boolean indicating whether the tokens have been added to the queue successfully or not.
  */
-async function queueUpdateTokenInfo(
+async function queueTokenInfoJobs(
   tokens: ITokenInfoJobDetails[]
 ): Promise<boolean> {
   try {
@@ -59,4 +59,4 @@ async function queueUpdateTokenInfo(
   }
 }
 
-export default queueUpdateTokenInfo
+export default queueTokenInfoJobs

--- a/src/lib/queueTokenInfoJobs.ts
+++ b/src/lib/queueTokenInfoJobs.ts
@@ -1,7 +1,7 @@
 import SQS from 'aws-sdk/clients/sqs'
 import Bluebird from 'bluebird'
 import { chunk, uniqBy } from 'lodash'
-import { QUEUE_URL } from './constants'
+import { TOKEN_INFO_QUEUE_URL } from './constants'
 import Logger from './logger'
 import stats from './stats'
 
@@ -10,7 +10,7 @@ const sqs = new SQS({
   apiVersion: 'latest'
 })
 
-export interface IJobDetails {
+export interface ITokenInfoJobDetails {
   tokenAddress: string
   tokenId?: Maybe<string>
 }
@@ -25,9 +25,11 @@ export interface IJobDetails {
  *
  * @returns {Promise<boolean>} `Promise<boolean>` - A boolean indicating whether the tokens have been added to the queue successfully or not.
  */
-async function queueTokenInfoJobs(tokens: IJobDetails[]): Promise<boolean> {
+async function queueTokenInfoJobs(
+  tokens: ITokenInfoJobDetails[]
+): Promise<boolean> {
   try {
-    if (!QUEUE_URL || !tokens.length) {
+    if (!TOKEN_INFO_QUEUE_URL || !tokens.length) {
       return false
     }
 
@@ -41,7 +43,7 @@ async function queueTokenInfoJobs(tokens: IJobDetails[]): Promise<boolean> {
     await Bluebird.Promise.mapSeries(chunk(uniqueTokens, 10), chunk =>
       sqs
         .sendMessageBatch({
-          QueueUrl: QUEUE_URL!,
+          QueueUrl: TOKEN_INFO_QUEUE_URL!,
           Entries: chunk.map((data, index) => ({
             Id: `t-${index}`,
             MessageBody: JSON.stringify(data)

--- a/src/lib/queueTokenInfoJobs.ts
+++ b/src/lib/queueTokenInfoJobs.ts
@@ -25,7 +25,7 @@ export interface ITokenInfoJobDetails {
  *
  * @returns {Promise<boolean>} `Promise<boolean>` - A boolean indicating whether the tokens have been added to the queue successfully or not.
  */
-async function queueTokenInfoJobs(
+async function queueUpdateTokenInfo(
   tokens: ITokenInfoJobDetails[]
 ): Promise<boolean> {
   try {
@@ -59,4 +59,4 @@ async function queueTokenInfoJobs(
   }
 }
 
-export default queueTokenInfoJobs
+export default queueUpdateTokenInfo

--- a/src/lib/realtimeProcessing.ts
+++ b/src/lib/realtimeProcessing.ts
@@ -1,9 +1,9 @@
-import { SyncingState } from '../@types'
+import { ProcessingGoal, SyncingState } from '../@types'
 import updateSyncingState from '../db/operations/statusTable/updateSyncingState'
 import { REALTIME_START_REPEAT } from './constants'
 import { getEthClient } from './getEthClient'
 import Logger from './logger'
-import processBlocks, { ProcessingGoal } from './processBlocks'
+import processBlocks from './processBlocks'
 
 const logger = Logger(module)
 

--- a/src/lib/updateContractInfo.ts
+++ b/src/lib/updateContractInfo.ts
@@ -29,14 +29,6 @@ const abi = [
 
 const logger = Logger(module)
 
-// async function getLatestBlock(tokenAddress: string) {
-//   const row = await sequelize.query<{ blockNumber: number }>(
-//     `SELECT "blockNumber" FROM "TokenTransfer" WHERE "tokenAddress" = '${tokenAddress}' ORDER BY "blockNumber" DESC LIMIT 1;`,
-//     { raw: true, type: QueryTypes.SELECT, plain: true }
-//   )
-//   return row?.blockNumber
-// }
-
 export async function updateExistingContractInfoByBlock({
   blockNumber,
   goal
@@ -49,7 +41,7 @@ export async function updateExistingContractInfoByBlock({
     blockNumber
   )
 
-  const possibleContractddresses = blockWithTransactions.transactions.reduce(
+  const possibleContractAddresses = blockWithTransactions.transactions.reduce(
     (map: { toAddress: Set<string>; fromAddress: Set<string> }, tx) => {
       if (tx.from) {
         map.fromAddress.add(tx.from.toLowerCase())
@@ -67,8 +59,8 @@ export async function updateExistingContractInfoByBlock({
     where: {
       address: {
         [Op.in]: [
-          ...possibleContractddresses.fromAddress,
-          ...possibleContractddresses.toAddress
+          ...possibleContractAddresses.fromAddress,
+          ...possibleContractAddresses.toAddress
         ]
       }
     }

--- a/src/lib/updateContractInfo.ts
+++ b/src/lib/updateContractInfo.ts
@@ -86,11 +86,6 @@ async function updateContractInfo({
     const client = await getEthClient()
     const contract = new Contract(address, abi, client)
 
-    client.getLogs({
-      address: tokenAddress,
-      fromBlock: contractInfo.lastTransactionBlock || 0
-    })
-
     const latestBlockNumber = blockNumber || (await getLatestBlock(address))
 
     const blockTIme = Date.now()

--- a/src/lib/updateContractInfo.ts
+++ b/src/lib/updateContractInfo.ts
@@ -52,10 +52,10 @@ export async function updateExistingContractInfoByBlock({
   const possibleContractddresses = blockWithTransactions.transactions.reduce(
     (map: { toAddress: Set<string>; fromAddress: Set<string> }, tx) => {
       if (tx.from) {
-        map.fromAddress.add(tx.from)
+        map.fromAddress.add(tx.from.toLowerCase())
       }
       if (tx.to) {
-        map.toAddress.add(tx.to)
+        map.toAddress.add(tx.to.toLowerCase())
       }
 
       return map

--- a/src/lib/updateContractInfo.ts
+++ b/src/lib/updateContractInfo.ts
@@ -76,9 +76,9 @@ async function updateContractInfo({
     // if creating new or stale, update all data no matter what
     if (
       created ||
-      (contractInfo.updatedMetaInfoAt &&
-        differenceInDays(Date.now(), contractInfo.updatedMetaInfoAt) >=
-          CONTRACT_INFO_MAX_AGE_IN_DAYS)
+      !contractInfo.updatedMetaInfoAt ||
+      differenceInDays(Date.now(), contractInfo.updatedMetaInfoAt) >=
+        CONTRACT_INFO_MAX_AGE_IN_DAYS
     ) {
       full = true
     }

--- a/src/lib/updateContractInfo.ts
+++ b/src/lib/updateContractInfo.ts
@@ -135,7 +135,7 @@ async function updateContractInfo({
     }
 
     await contractInfo.save()
-    stats.histogram('update_contract_called', Date.now() - startTime)
+    stats.histogram('update_contract_finished', Date.now() - startTime)
     console.log('time taken', Date.now() - startTime)
   } catch (err) {
     console.log(err)

--- a/src/lib/updateContractInfo.ts
+++ b/src/lib/updateContractInfo.ts
@@ -1,0 +1,152 @@
+import 'dotenv/config'
+import 'module-alias/register'
+import 'source-map-support/register'
+
+import { differenceInDays, isAfter } from 'date-fns'
+import { Contract, BigNumber as BN } from 'ethers'
+import { QueryTypes } from 'sequelize'
+import knownContracts from '../common/knownContracts'
+import { CONTRACT_INFO_MAX_AGE_IN_DAYS } from './constants'
+import getContractSpec from './getContractSpec'
+import { getEthClient } from './getEthClient'
+import Logger from './logger'
+import { IContractInfoJobDetails } from './queueContractInfoJobs'
+import safeCall from './safeCall'
+import stats from './stats'
+import { ContractInfo } from '@models/ContractInfo/ContractInfo'
+import { sequelize } from '@models/index'
+import { ProcessingGoal } from '@types'
+
+const abi = [
+  'function decimals() view returns (uint8)',
+  'function name() view returns (string)',
+  'function symbol() view returns (string)'
+]
+
+const logger = Logger(module)
+
+async function getLatestBlock(tokenAddress: string) {
+  const row = await sequelize.query<{ blockNumber: number }>(
+    `SELECT
+      "blockNumber"
+    FROM
+      "TokenTransfer"
+    WHERE
+      "tokenAddress" = '${tokenAddress}'
+    ORDER BY
+      "blockNumber" DESC
+    LIMIT 1;`,
+    { raw: true, type: QueryTypes.SELECT, plain: true }
+  )
+  return row?.blockNumber
+}
+
+/**
+ * Update, or add, a contracts's metadata into the `ContractInfo` table.
+ *
+ * @remarks
+ * This function not only gets metadata from the contract in the blockchain itself.
+ *
+ * @param {tokenAddress} tokenAddress - The address of the token.
+ * @param {latestBlockNumber} latestBlockNumber - The block number of token transfer.
+
+ * @returns {Promise<void>} This function does not return any useful value.
+ */
+async function updateContractInfo({
+  tokenAddress,
+  blockNumber,
+  goal,
+  full = false
+}: IContractInfoJobDetails): Promise<void> {
+  const address = tokenAddress.toLowerCase()
+  const startTime = Date.now()
+  stats.increment('update_contract_called')
+
+  try {
+    const [contractInfo, created] = await ContractInfo.findOrCreate({
+      where: {
+        address
+      }
+    })
+
+    if (!created && goal === ProcessingGoal.BACKFILL) {
+      return
+    }
+
+    // if creating new or stale, update all data no matter what
+    if (
+      created ||
+      (contractInfo.updatedMetaInfoAt &&
+        differenceInDays(Date.now(), contractInfo.updatedMetaInfoAt) >=
+          CONTRACT_INFO_MAX_AGE_IN_DAYS)
+    ) {
+      full = true
+    }
+
+    const client = await getEthClient()
+    const contract = new Contract(address, abi, client)
+
+    client.getLogs({
+      address: tokenAddress,
+      fromBlock: contractInfo.lastTransactionBlock || 0
+    })
+
+    const latestBlockNumber = blockNumber || (await getLatestBlock(address))
+
+    const blockTIme = Date.now()
+    const [contractName, symbol, decimals, tokenType, ethBalance, block] =
+      await Promise.all([
+        full ? safeCall<string>(contract, 'name') : contractInfo.name,
+        full ? safeCall<string>(contract, 'symbol') : contractInfo.symbol,
+        full ? safeCall<BN>(contract, 'decimals') : contractInfo.decimals,
+        full ? getContractSpec(address) : contractInfo.tokenType,
+        client.getBalance(address),
+        latestBlockNumber ? client.getBlock(latestBlockNumber) : undefined
+      ])
+
+    console.log(
+      `time take for block and eth balance = ${Date.now() - blockTIme}`
+    )
+
+    // full
+    contractInfo.name = contractName || knownContracts[address]?.name
+    contractInfo.symbol = symbol || knownContracts[address]?.symbol
+    contractInfo.tokenType = tokenType
+    contractInfo.decimals = decimals
+      ? +decimals.toString()
+      : knownContracts[address]?.decimals
+    if (full) {
+      contractInfo.updatedMetaInfoAt = new Date()
+    }
+
+    // always
+    contractInfo.ethBalance = BigInt(ethBalance.toString())
+
+    if (
+      latestBlockNumber &&
+      latestBlockNumber > (contractInfo.lastTransactionBlock || 0)
+    ) {
+      contractInfo.lastTransactionBlock = latestBlockNumber
+    }
+
+    if (block?.timestamp) {
+      const blockTimestanp = new Date(block.timestamp * 1000)
+      if (
+        !contractInfo.lastTransactionAt ||
+        isAfter(blockTimestanp, contractInfo.lastTransactionAt)
+      ) {
+        contractInfo.lastTransactionAt = new Date(block.timestamp * 1000)
+      }
+    }
+
+    await contractInfo.save()
+    stats.histogram('update_contract_called', Date.now() - startTime)
+    console.log('time taken', Date.now() - startTime)
+  } catch (err) {
+    console.log(err)
+    logger.warn(`Failed at updateContractInfo(${tokenAddress}, ${err}`)
+    stats.histogram('update_contract_failed', Date.now() - startTime)
+  }
+}
+
+export default updateContractInfo

--- a/src/lib/updateContractInfo.ts
+++ b/src/lib/updateContractInfo.ts
@@ -162,12 +162,12 @@ export async function updateContractInfoByTokenAddress(
     if (updateBlockMetrics) {
       contractInfo.lastTransactionBlock = transferBlockNumber
       if (block?.timestamp) {
-        const blockTimestanp = new Date(block.timestamp * 1000)
+        const blockTimestamp = new Date(block.timestamp * 1000)
         if (
           !contractInfo.lastTransactionAt ||
-          isAfter(blockTimestanp, contractInfo.lastTransactionAt)
+          isAfter(blockTimestamp, contractInfo.lastTransactionAt)
         ) {
-          contractInfo.lastTransactionAt = blockTimestanp
+          contractInfo.lastTransactionAt = blockTimestamp
         }
       }
     }

--- a/src/lib/updateContractInfo.ts
+++ b/src/lib/updateContractInfo.ts
@@ -29,6 +29,14 @@ const abi = [
 
 const logger = Logger(module)
 
+// async function getLatestBlock(tokenAddress: string) {
+//   const row = await sequelize.query<{ blockNumber: number }>(
+//     `SELECT "blockNumber" FROM "TokenTransfer" WHERE "tokenAddress" = '${tokenAddress}' ORDER BY "blockNumber" DESC LIMIT 1;`,
+//     { raw: true, type: QueryTypes.SELECT, plain: true }
+//   )
+//   return row?.blockNumber
+// }
+
 export async function updateExistingContractInfoByBlock({
   blockNumber,
   goal
@@ -128,7 +136,7 @@ export async function updateContractInfoByTokenAddress(
       (!contractInfo.lastTransactionBlock ||
         transferBlockNumber > contractInfo.lastTransactionBlock)
 
-    if (!updateSpec && !shouldUpdateBlockMetrics && !contractInfo.ethBalance) {
+    if (!updateSpec && !shouldUpdateBlockMetrics && contractInfo.ethBalance) {
       stats.increment('update_token_not_stale')
       return
     }
@@ -170,9 +178,8 @@ export async function updateContractInfoByTokenAddress(
           contractInfo.lastTransactionAt = blockTimestanp
         }
       }
-
-      contractInfo.ethBalance = BigInt(ethBalance.toString())
     }
+    contractInfo.ethBalance = BigInt(ethBalance.toString())
 
     await contractInfo.save()
     stats.histogram('update_contract_finished', Date.now() - startTime)

--- a/src/lib/updateContractInfo.ts
+++ b/src/lib/updateContractInfo.ts
@@ -109,6 +109,7 @@ export async function updateContractInfoByTokenAddress(
 
     if (!created && goal === ProcessingGoal.BACKFILL) {
       stats.increment('update_contract_backfill')
+      return
     }
 
     const updateSpec =
@@ -125,6 +126,7 @@ export async function updateContractInfoByTokenAddress(
 
     if (!updateSpec && !updateBlockMetrics && contractInfo.ethBalance) {
       stats.increment('update_contract_not_stale')
+      return
     }
 
     const client = await getEthClient()

--- a/src/lib/updateContractInfo.ts
+++ b/src/lib/updateContractInfo.ts
@@ -88,7 +88,6 @@ async function updateContractInfo({
 
     const latestBlockNumber = blockNumber || (await getLatestBlock(address))
 
-    const blockTIme = Date.now()
     const [contractName, symbol, decimals, tokenType, ethBalance, block] =
       await Promise.all([
         full ? safeCall<string>(contract, 'name') : contractInfo.name,
@@ -98,10 +97,6 @@ async function updateContractInfo({
         client.getBalance(address),
         latestBlockNumber ? client.getBlock(latestBlockNumber) : undefined
       ])
-
-    console.log(
-      `time take for block and eth balance = ${Date.now() - blockTIme}`
-    )
 
     // full
     contractInfo.name = contractName || knownContracts[address]?.name
@@ -136,7 +131,6 @@ async function updateContractInfo({
 
     await contractInfo.save()
     stats.histogram('update_contract_finished', Date.now() - startTime)
-    console.log('time taken', Date.now() - startTime)
   } catch (err) {
     console.log(err)
     logger.warn(`Failed at updateContractInfo(${tokenAddress}, ${err}`)

--- a/src/lib/updateContractInfo.ts
+++ b/src/lib/updateContractInfo.ts
@@ -30,8 +30,12 @@ const abi = [
 const logger = Logger(module)
 
 export async function updateExistingContractInfoByBlock({
-  blockNumber
+  blockNumber,
+  goal
 }: IContractInfoJobDetailsByBlock): Promise<void> {
+  if (goal === ProcessingGoal.BACKFILL) {
+    return
+  }
   const client = await getEthClient()
   const blockWithTransactions = await client.getBlockWithTransactions(
     blockNumber
@@ -74,9 +78,13 @@ export async function updateExistingContractInfoByBlock({
 
 /**
  * Update, or add, a contracts's metadata into the `ContractInfo` table.
- * @remarks This function not only gets metadata from the contract in the blockchain itself.
- * @param {transferObject} transferObject - {tokenAddress: The address of the token, transferBlockNumber: Optional transfer block number, goal: Optional Current goal of the process, fullUpdate: Optional boolean whether to perform full update}
- * @param {blockWithTransactions} blockWithTransactions - The block (with transactions) when updating contractinfo by block.
+ *
+ * @remarks
+ * This function not only gets metadata from the contract in the blockchain itself.
+ *
+ * @param {tokenAddress} tokenAddress - The address of the token.
+ * @param {blockNumber} blockWithTransactions - The block (with transactions) when updating contractinfo by block.
+
  * @returns {Promise<void>} This function does not return any useful value.
  */
 export async function updateContractInfoByTokenAddress(
@@ -87,7 +95,7 @@ export async function updateContractInfoByTokenAddress(
     fullUpdate = false
   }: IContractInfoJobDetailsByTokenAddress,
   blockWithTransactions?: BlockWithTransactions
-): Promise<ContractInfo> {
+): Promise<void> {
   const address = tokenAddress.toLowerCase()
   const startTime = Date.now()
   stats.increment('update_contract_called')
@@ -101,7 +109,7 @@ export async function updateContractInfoByTokenAddress(
 
     if (!created && goal === ProcessingGoal.BACKFILL) {
       stats.increment('update_contract_backfill')
-      return contractInfo
+      return
     }
 
     const updateSpec =
@@ -118,7 +126,7 @@ export async function updateContractInfoByTokenAddress(
 
     if (!updateSpec && !updateBlockMetrics && contractInfo.ethBalance) {
       stats.increment('update_contract_not_stale')
-      return contractInfo
+      return
     }
 
     const client = await getEthClient()
@@ -163,14 +171,9 @@ export async function updateContractInfoByTokenAddress(
 
     await contractInfo.save()
     stats.histogram('update_contract_finished', Date.now() - startTime)
-    return contractInfo
   } catch (err) {
+    console.log(err)
     logger.warn(`Failed at updateContractInfo(${tokenAddress}, ${err}`)
     stats.histogram('update_contract_failed', Date.now() - startTime)
-    throw new Error(
-      `Failed at updateContractInfo:[${tokenAddress}] block: [${
-        transferBlockNumber || blockWithTransactions?.number
-      }]`
-    )
   }
 }

--- a/src/lib/updateContractInfo.ts
+++ b/src/lib/updateContractInfo.ts
@@ -131,12 +131,12 @@ export async function updateContractInfoByTokenAddress(
         differenceInDays(Date.now(), contractInfo.updatedMetaInfoAt) >=
           CONTRACT_INFO_MAX_AGE_IN_DAYS)
 
-    const shouldUpdateBlockMetrics =
+    const updateBlockMetrics =
       !!transferBlockNumber &&
       (!contractInfo.lastTransactionBlock ||
         transferBlockNumber > contractInfo.lastTransactionBlock)
 
-    if (!updateSpec && !shouldUpdateBlockMetrics && contractInfo.ethBalance) {
+    if (!updateSpec && !updateBlockMetrics && contractInfo.ethBalance) {
       stats.increment('update_token_not_stale')
       return
     }
@@ -151,7 +151,7 @@ export async function updateContractInfoByTokenAddress(
         updateSpec ? safeCall<BN>(contract, 'decimals') : contractInfo.decimals,
         updateSpec ? getContractSpec(address) : contractInfo.tokenType,
         client.getBalance(address),
-        shouldUpdateBlockMetrics
+        updateBlockMetrics
           ? blockWithTransactions || client.getBlock(transferBlockNumber)
           : undefined
       ])
@@ -167,7 +167,7 @@ export async function updateContractInfoByTokenAddress(
       contractInfo.updatedMetaInfoAt = new Date()
     }
 
-    if (shouldUpdateBlockMetrics) {
+    if (updateBlockMetrics) {
       contractInfo.lastTransactionBlock = transferBlockNumber
       if (block?.timestamp) {
         const blockTimestanp = new Date(block.timestamp * 1000)

--- a/src/lib/updateContractInfo.ts
+++ b/src/lib/updateContractInfo.ts
@@ -125,11 +125,11 @@ export async function updateContractInfoByTokenAddress(
     }
 
     const updateSpec =
-      !fullUpdate &&
-      (created ||
-        !contractInfo.updatedMetaInfoAt ||
-        differenceInDays(Date.now(), contractInfo.updatedMetaInfoAt) >=
-          CONTRACT_INFO_MAX_AGE_IN_DAYS)
+      fullUpdate ||
+      created ||
+      !contractInfo.updatedMetaInfoAt ||
+      differenceInDays(Date.now(), contractInfo.updatedMetaInfoAt) >=
+        CONTRACT_INFO_MAX_AGE_IN_DAYS
 
     const updateBlockMetrics =
       !!transferBlockNumber &&

--- a/src/lib/updateContractInfo.ts
+++ b/src/lib/updateContractInfo.ts
@@ -18,7 +18,7 @@ import {
 } from './queueContractInfoJobs'
 import safeCall from './safeCall'
 import stats from './stats'
-import { ContractInfo } from '@models/ContractInfo/ContractInfo'
+import { ContractInfo } from '@models/index'
 import { ProcessingGoal } from '@types'
 
 const abi = [

--- a/src/lib/updateTokenInfo.ts
+++ b/src/lib/updateTokenInfo.ts
@@ -7,7 +7,8 @@ import Logger from './logger'
 import safeCall from './safeCall'
 import stats from './stats'
 import substituteTokenID from './substituteTokenID'
-import { ContractInfo, TokenInfo } from '@models/index'
+import { ContractInfo } from '@models/ContractInfo/ContractInfo'
+import { TokenInfo } from '@models/TokenInfo/TokenInfo'
 import { getCorrectTokenUrlsByExtension } from '@utils/tokenInfoHelper'
 
 const abi = [

--- a/src/lib/updateTokenInfo.ts
+++ b/src/lib/updateTokenInfo.ts
@@ -41,7 +41,6 @@ async function updateTokenInfo(
     const [contractInfo] = await ContractInfo.findOrCreate({
       where: {
         address
-        // coalesce to null, since `undefined` isn't a valid sequelize value
       }
     })
     const [token, created] = await TokenInfo.findOrCreate({

--- a/src/lib/updateTokenInfo.ts
+++ b/src/lib/updateTokenInfo.ts
@@ -1,21 +1,17 @@
 import differenceInDays from 'date-fns/differenceInDays'
-import { Contract, BigNumber as BN } from 'ethers'
-import knownContracts from '../common/knownContracts'
-import { TokenInfo } from '../models/TokenInfo/TokenInfo'
-import { getCorrectTokenUrlsByExtension } from '../utils/tokenInfoHelper'
+import { Contract } from 'ethers'
 import { TOKEN_INFO_MAX_AGE_IN_DAYS } from './constants'
 import fetchRemoteMetadata from './fetchRemoteMetadata'
-import getContractSpec from './getContractSpec'
 import { getEthClient } from './getEthClient'
 import Logger from './logger'
 import safeCall from './safeCall'
 import stats from './stats'
 import substituteTokenID from './substituteTokenID'
+import { ContractInfo } from '@models/ContractInfo/ContractInfo'
+import { TokenInfo } from '@models/TokenInfo/TokenInfo'
+import { getCorrectTokenUrlsByExtension } from '@utils/tokenInfoHelper'
 
 const abi = [
-  'function name() view returns (string)',
-  'function symbol() view returns (string)',
-  'function decimals() view returns (uint8)',
   'function tokenURI(uint256 _tokenId) external view returns (string)',
   'function uri(uint256 _id) external view returns (string memory)'
 ]
@@ -26,7 +22,7 @@ const logger = Logger(module)
  * Update, or add, a token's metadata into the `TokenInfo` table.
  *
  * @remarks
- * This function not only gets metada from the contract in the blockchain itself, but also externally hosted metadata if there's a `tokenURI` present.
+ * This function not only gets metadata from the contract in the blockchain itself, but also externally hosted metadata if there's a `tokenURI` present.
  *
  * @param {tokenAddress} tokenAddress - The address of the token.
  * @param {tokenId} tokenId - The token's Id, if it exists.
@@ -39,13 +35,25 @@ async function updateTokenInfo(
 ): Promise<void> {
   const startTime = Date.now()
   stats.increment('update_token_called')
+  const address = tokenAddress.toLowerCase()
 
   try {
+    const [contractInfo] = await ContractInfo.findOrCreate({
+      where: {
+        address
+        // coalesce to null, since `undefined` isn't a valid sequelize value
+      }
+    })
     const [token, created] = await TokenInfo.findOrCreate({
       where: {
-        address: tokenAddress.toLowerCase(),
+        address,
         // coalesce to null, since `undefined` isn't a valid sequelize value
         tokenId: tokenId ?? null
+      },
+      defaults: {
+        address,
+        tokenId: tokenId ?? null,
+        contractInfoId: contractInfo.id
       }
     })
 
@@ -59,29 +67,15 @@ async function updateTokenInfo(
 
     const client = await getEthClient()
     const contract = new Contract(tokenAddress, abi, client)
-    const [contractName, symbol, decimals, tokenURI, uri] = await Promise.all([
-      safeCall<string>(contract, 'name'),
-      safeCall<string>(contract, 'symbol'),
-      safeCall<BN>(contract, 'decimals'),
+    const [tokenURI, uri] = await Promise.all([
       safeCall<string>(contract, 'tokenURI', tokenId),
       safeCall<string>(contract, 'uri', tokenId)
     ])
 
-    token.contractName =
-      contractName || token.contractName || knownContracts[tokenAddress]?.name
-    token.symbol =
-      symbol || token.symbol || knownContracts[tokenAddress]?.symbol
-    token.decimals =
-      (decimals ? +decimals.toString() : token.decimals) ||
-      knownContracts[tokenAddress]?.decimals
     token.tokenUri = substituteTokenID(
       tokenURI || uri || token.tokenUri,
       tokenId
     )
-
-    if (!token.tokenType) {
-      token.tokenType = await getContractSpec(token.address)
-    }
 
     if (token.tokenUri) {
       const metadata = await fetchRemoteMetadata(token.tokenUri)
@@ -101,6 +95,8 @@ async function updateTokenInfo(
         token.animationUrl = correctUrlData.animationUrl
       }
     }
+
+    token.contractInfoId = contractInfo.id
 
     await token.save()
     stats.histogram('update_token_finished', Date.now() - startTime)

--- a/src/lib/updateTokenInfo.ts
+++ b/src/lib/updateTokenInfo.ts
@@ -4,11 +4,11 @@ import { TOKEN_INFO_MAX_AGE_IN_DAYS } from './constants'
 import fetchRemoteMetadata from './fetchRemoteMetadata'
 import { getEthClient } from './getEthClient'
 import Logger from './logger'
+import { ITokenInfoJobDetails } from './queueTokenInfoJobs'
 import safeCall from './safeCall'
 import stats from './stats'
 import substituteTokenID from './substituteTokenID'
-import { ContractInfo } from '@models/ContractInfo/ContractInfo'
-import { TokenInfo } from '@models/TokenInfo/TokenInfo'
+import { ContractInfo, TokenInfo } from '@models/index'
 import { getCorrectTokenUrlsByExtension } from '@utils/tokenInfoHelper'
 
 const abi = [
@@ -29,10 +29,10 @@ const logger = Logger(module)
  *
  * @returns {Promise<void>} This function does not return any useful value.
  */
-async function updateTokenInfo(
-  tokenAddress: string,
-  tokenId?: Maybe<string>
-): Promise<void> {
+async function updateTokenInfo({
+  tokenAddress,
+  tokenId
+}: ITokenInfoJobDetails): Promise<void> {
   const startTime = Date.now()
   stats.increment('update_token_called')
   const address = tokenAddress.toLowerCase()

--- a/src/lib/updateTokenInfo.ts
+++ b/src/lib/updateTokenInfo.ts
@@ -4,11 +4,11 @@ import { TOKEN_INFO_MAX_AGE_IN_DAYS } from './constants'
 import fetchRemoteMetadata from './fetchRemoteMetadata'
 import { getEthClient } from './getEthClient'
 import Logger from './logger'
-import { ITokenInfoJobDetails } from './queueTokenInfoJobs'
 import safeCall from './safeCall'
 import stats from './stats'
 import substituteTokenID from './substituteTokenID'
-import { ContractInfo, TokenInfo } from '@models/index'
+import { ContractInfo } from '@models/ContractInfo/ContractInfo'
+import { TokenInfo } from '@models/TokenInfo/TokenInfo'
 import { getCorrectTokenUrlsByExtension } from '@utils/tokenInfoHelper'
 
 const abi = [
@@ -29,10 +29,10 @@ const logger = Logger(module)
  *
  * @returns {Promise<void>} This function does not return any useful value.
  */
-async function updateTokenInfo({
-  tokenAddress,
-  tokenId
-}: ITokenInfoJobDetails): Promise<void> {
+async function updateTokenInfo(
+  tokenAddress: string,
+  tokenId?: Maybe<string>
+): Promise<void> {
   const startTime = Date.now()
   stats.increment('update_token_called')
   const address = tokenAddress.toLowerCase()

--- a/src/lib/updateTokenInfo.ts
+++ b/src/lib/updateTokenInfo.ts
@@ -7,8 +7,7 @@ import Logger from './logger'
 import safeCall from './safeCall'
 import stats from './stats'
 import substituteTokenID from './substituteTokenID'
-import { ContractInfo } from '@models/ContractInfo/ContractInfo'
-import { TokenInfo } from '@models/TokenInfo/TokenInfo'
+import { ContractInfo, TokenInfo } from '@models/index'
 import { getCorrectTokenUrlsByExtension } from '@utils/tokenInfoHelper'
 
 const abi = [

--- a/src/migrations/20220922125510-add-status-table.ts
+++ b/src/migrations/20220922125510-add-status-table.ts
@@ -6,7 +6,7 @@ import 'source-map-support/register'
 
 import { DataTypes, QueryInterface, Sequelize } from 'sequelize'
 import { SyncingState } from '../@types'
-import { Status } from '../models/index'
+import { Status } from '@models/index'
 
 interface IMigration {
   up: (queryInterface: QueryInterface, sequelize: Sequelize) => Promise<void>

--- a/src/migrations/20220922125510-add-status-table.ts
+++ b/src/migrations/20220922125510-add-status-table.ts
@@ -6,7 +6,7 @@ import 'source-map-support/register'
 
 import { DataTypes, QueryInterface, Sequelize } from 'sequelize'
 import { SyncingState } from '../@types'
-import { Status } from '@models/index'
+import { Status } from '../models/index'
 
 interface IMigration {
   up: (queryInterface: QueryInterface, sequelize: Sequelize) => Promise<void>

--- a/src/migrations/20230217103300-add-contract-info-table.ts
+++ b/src/migrations/20230217103300-add-contract-info-table.ts
@@ -1,0 +1,89 @@
+'use strict'
+
+import 'dotenv/config'
+import 'module-alias/register'
+import 'source-map-support/register'
+
+import { DataTypes, QueryInterface, Sequelize } from 'sequelize'
+import { TokenType } from '@types'
+
+interface IMigration {
+  up: (queryInterface: QueryInterface, sequelize: Sequelize) => Promise<void>
+  down: (queryInterface: QueryInterface, sequelize: Sequelize) => Promise<void>
+}
+
+/**
+ * Typescript based sequelize migration
+ * @see https://sequelize.org/master/manual/migrations.html
+ */
+
+const migration: IMigration = {
+  up: async queryInterface => {
+    await queryInterface.createTable('ContractInfo', {
+      id: {
+        type: DataTypes.INTEGER,
+        primaryKey: true,
+        autoIncrement: true
+      },
+      address: {
+        type: DataTypes.STRING,
+        allowNull: false,
+        unique: 'contract_info_address_idx'
+      },
+      tokenType: {
+        type: DataTypes.ENUM(...Object.values(TokenType)),
+        allowNull: true
+      },
+      name: {
+        type: DataTypes.TEXT,
+        allowNull: true
+      },
+      symbol: {
+        type: DataTypes.TEXT,
+        allowNull: true
+      },
+      ethBalance: {
+        type: DataTypes.DECIMAL,
+        allowNull: true
+      },
+      decimals: {
+        type: DataTypes.INTEGER,
+        allowNull: true
+      },
+      lastTransactionBlock: {
+        type: DataTypes.INTEGER,
+        allowNull: true,
+        defaultValue: 0
+      },
+      lastTransactionAt: {
+        type: DataTypes.DATE,
+        allowNull: true
+      },
+      updatedMetaInfoAt: {
+        type: DataTypes.DATE,
+        allowNull: true
+      },
+      updatedAt: {
+        type: DataTypes.DATE,
+        allowNull: false
+      }
+    })
+
+    // add column for migration and later reference
+    await queryInterface.addIndex('ContractInfo', ['address'], {
+      name: 'contract_info_address_idx',
+      unique: true
+    })
+
+    await queryInterface.addColumn('TokenInfo', 'contractInfoId', {
+      type: DataTypes.INTEGER,
+      allowNull: true
+    })
+  },
+
+  down: async queryInterface => {
+    await queryInterface.dropTable('ContractInfo')
+  }
+}
+
+export default migration

--- a/src/migrations/20230217103300-add-contract-info-table.ts
+++ b/src/migrations/20230217103300-add-contract-info-table.ts
@@ -81,6 +81,11 @@ const migration: IMigration = {
   },
 
   down: async queryInterface => {
+    await queryInterface.removeIndex(
+      'ContractInfo',
+      'contract_info_address_idx'
+    )
+    await queryInterface.removeColumn('TokenInfo', 'contractInfoId')
     await queryInterface.dropTable('ContractInfo')
   }
 }

--- a/src/migrations/20230217103300-add-contract-info-table.ts
+++ b/src/migrations/20230217103300-add-contract-info-table.ts
@@ -52,8 +52,7 @@ const migration: IMigration = {
       },
       lastTransactionBlock: {
         type: DataTypes.INTEGER,
-        allowNull: true,
-        defaultValue: 0
+        allowNull: true
       },
       lastTransactionAt: {
         type: DataTypes.DATE,

--- a/src/migrations/20230217103337-migrate-contract-info-from-token-info.ts
+++ b/src/migrations/20230217103337-migrate-contract-info-from-token-info.ts
@@ -106,7 +106,6 @@ const migration: IMigration = {
     await queryInterface.sequelize.query(`call update_contract_info_id();`, {
       raw: true
     })
-    await queueContractInfoBackfill({})
   },
 
   down: async () => {

--- a/src/migrations/20230217103337-migrate-contract-info-from-token-info.ts
+++ b/src/migrations/20230217103337-migrate-contract-info-from-token-info.ts
@@ -1,0 +1,123 @@
+'use strict'
+
+import 'dotenv/config'
+import 'module-alias/register'
+import 'source-map-support/register'
+
+import { QueryInterface, QueryTypes, Sequelize } from 'sequelize'
+import { queueContractInfoBackfill } from '@lib/queueContractInfoJobs'
+
+interface IMigration {
+  up: (queryInterface: QueryInterface, sequelize: Sequelize) => Promise<void>
+  down: (queryInterface: QueryInterface, sequelize: Sequelize) => Promise<void>
+}
+
+/**
+ * Typescript based sequelize migration
+ * @see https://sequelize.org/master/manual/migrations.html
+ */
+
+const migration: IMigration = {
+  up: async queryInterface => {
+    await queryInterface.sequelize.query(
+      `
+    INSERT INTO "ContractInfo" (address, "tokenType", "name", symbol, decimals, "updatedAt", "updatedMetaInfoAt")
+    SELECT
+      address,
+      ("tokenType"::text)::"enum_ContractInfo_tokenType",
+      "contractName",
+      symbol,
+      decimals,
+      now(),
+      now()
+    FROM (
+      SELECT
+        address,
+        "tokenType",
+        "contractName",
+        symbol,
+        decimals
+      FROM ( SELECT DISTINCT
+          address,
+          "tokenType",
+          "contractName",
+          symbol,
+          decimals,
+          ROW_NUMBER() OVER (PARTITION BY address ORDER BY "updatedAt" DESC) AS rowNum
+        FROM
+          "TokenInfo"
+        WHERE
+          address NOT in(
+          SELECT
+            address FROM "ContractInfo")) d
+      WHERE
+        rowNum = 1) d2;`,
+      {
+        raw: true,
+        type: QueryTypes.INSERT
+      }
+    )
+
+    await queryInterface.sequelize.query(
+      `CREATE OR REPLACE PROCEDURE public.update_contract_info_id()
+    LANGUAGE plpgsql
+   AS $procedure$
+   DECLARE
+     _id int := (
+       SELECT
+         min(id)
+       FROM
+         "TokenInfo"
+       WHERE
+         "contractInfoId" IS NULL);
+     _max_id int := (
+       SELECT
+         max(id)
+       FROM
+         "TokenInfo"
+       WHERE
+         "contractInfoId" IS NULL);
+     _batch_size int = 100000;
+   BEGIN
+     LOOP
+       RAISE NOTICE 'updating IDs from % to %', _id, _id + _batch_size;
+       UPDATE
+         "TokenInfo"
+       SET
+         "contractInfoId" = "ContractInfo".id
+       FROM
+         "ContractInfo"
+       WHERE
+         "TokenInfo".address = "ContractInfo".address
+         AND "TokenInfo".id >= _id
+         AND "TokenInfo".id < _id + _batch_size
+         AND "contractInfoId" IS NULL;
+       COMMIT;
+       _id := _id + _batch_size;
+       IF _id > _max_id THEN
+         EXIT;
+       END IF;
+     END LOOP;
+   END;
+   $procedure$`,
+      { raw: true }
+    )
+
+    await queryInterface.sequelize.query(`call update_contract_info_id();`, {
+      raw: true
+    })
+
+    queueContractInfoBackfill({})
+  },
+
+  down: async () => {
+    /**
+     * Add reverting commands here.
+     *
+     * Example:
+     * await queryInterface.dropTable('users');
+     */
+  }
+}
+
+export default migration

--- a/src/migrations/20230217103337-migrate-contract-info-from-token-info.ts
+++ b/src/migrations/20230217103337-migrate-contract-info-from-token-info.ts
@@ -5,7 +5,6 @@ import 'module-alias/register'
 import 'source-map-support/register'
 
 import { QueryInterface, QueryTypes, Sequelize } from 'sequelize'
-import { queueContractInfoBackfill } from '@lib/queueContractInfoJobs'
 
 interface IMigration {
   up: (queryInterface: QueryInterface, sequelize: Sequelize) => Promise<void>

--- a/src/migrations/20230217103337-migrate-contract-info-from-token-info.ts
+++ b/src/migrations/20230217103337-migrate-contract-info-from-token-info.ts
@@ -21,37 +21,37 @@ const migration: IMigration = {
   up: async queryInterface => {
     await queryInterface.sequelize.query(
       `
-    INSERT INTO "ContractInfo" (address, "tokenType", "name", symbol, decimals, "updatedAt", "updatedMetaInfoAt")
-    SELECT
-      address,
-      ("tokenType"::text)::"enum_ContractInfo_tokenType",
-      "contractName",
-      symbol,
-      decimals,
-      now(),
-      now()
-    FROM (
+      INSERT INTO "ContractInfo" (address, "tokenType", "name", symbol, decimals, "updatedAt", "updatedMetaInfoAt")
       SELECT
         address,
-        "tokenType",
+        ("tokenType"::text)::"enum_ContractInfo_tokenType",
         "contractName",
         symbol,
-        decimals
-      FROM ( SELECT DISTINCT
+        decimals,
+        now(),
+        now()
+      FROM (
+        SELECT
           address,
           "tokenType",
           "contractName",
           symbol,
-          decimals,
-          ROW_NUMBER() OVER (PARTITION BY address ORDER BY "updatedAt" DESC) AS rowNum
-        FROM
-          "TokenInfo"
+          decimals
+        FROM ( SELECT DISTINCT
+            address,
+            "tokenType",
+            "contractName",
+            symbol,
+            decimals,
+            ROW_NUMBER() OVER (PARTITION BY address ORDER BY "updatedAt" DESC) AS rowNum
+          FROM
+            "TokenInfo"
+          WHERE
+            address NOT in(
+            SELECT
+              address FROM "ContractInfo")) d
         WHERE
-          address NOT in(
-          SELECT
-            address FROM "ContractInfo")) d
-      WHERE
-        rowNum = 1) d2;`,
+          rowNum = 1) d2;`,
       {
         raw: true,
         type: QueryTypes.INSERT
@@ -60,54 +60,53 @@ const migration: IMigration = {
 
     await queryInterface.sequelize.query(
       `CREATE OR REPLACE PROCEDURE public.update_contract_info_id()
-    LANGUAGE plpgsql
-   AS $procedure$
-   DECLARE
-     _id int := (
-       SELECT
-         min(id)
-       FROM
-         "TokenInfo"
-       WHERE
-         "contractInfoId" IS NULL);
-     _max_id int := (
-       SELECT
-         max(id)
-       FROM
-         "TokenInfo"
-       WHERE
-         "contractInfoId" IS NULL);
-     _batch_size int = 100000;
-   BEGIN
-     LOOP
-       RAISE NOTICE 'updating IDs from % to %', _id, _id + _batch_size;
-       UPDATE
-         "TokenInfo"
-       SET
-         "contractInfoId" = "ContractInfo".id
-       FROM
-         "ContractInfo"
-       WHERE
-         "TokenInfo".address = "ContractInfo".address
-         AND "TokenInfo".id >= _id
-         AND "TokenInfo".id < _id + _batch_size
-         AND "contractInfoId" IS NULL;
-       COMMIT;
-       _id := _id + _batch_size;
-       IF _id > _max_id THEN
-         EXIT;
-       END IF;
-     END LOOP;
-   END;
-   $procedure$`,
+        LANGUAGE plpgsql
+        AS $procedure$
+        DECLARE
+          _id int := (
+            SELECT
+              min(id)
+            FROM
+              "TokenInfo"
+            WHERE
+              "contractInfoId" IS NULL);
+          _max_id int := (
+            SELECT
+              max(id)
+            FROM
+              "TokenInfo"
+            WHERE
+              "contractInfoId" IS NULL);
+          _batch_size int = 100000;
+        BEGIN
+          LOOP
+            RAISE NOTICE 'updating IDs from % to %', _id, _id + _batch_size;
+            UPDATE
+              "TokenInfo"
+            SET
+              "contractInfoId" = "ContractInfo".id
+            FROM
+              "ContractInfo"
+            WHERE
+              "TokenInfo".address = "ContractInfo".address
+              AND "TokenInfo".id >= _id
+              AND "TokenInfo".id < _id + _batch_size
+              AND "contractInfoId" IS NULL;
+            COMMIT;
+            _id := _id + _batch_size;
+            IF _id > _max_id THEN
+              EXIT;
+            END IF;
+          END LOOP;
+        END;
+        $procedure$`,
       { raw: true }
     )
 
     await queryInterface.sequelize.query(`call update_contract_info_id();`, {
       raw: true
     })
-
-    queueContractInfoBackfill({})
+    await queueContractInfoBackfill({})
   },
 
   down: async () => {

--- a/src/migrations/20230217103337-migrate-contract-info-from-token-info.ts
+++ b/src/migrations/20230217103337-migrate-contract-info-from-token-info.ts
@@ -113,7 +113,7 @@ const migration: IMigration = {
   },
 
   down: async queryInterface => {
-    await queryInterface.removeConstraint('TokenInfo', 'contractInfoId')
+    await queryInterface.removeIndex('TokenInfo', 'contractInfoId')
     await queryInterface.sequelize.query(
       `DROP PROCEDURE IF EXISTS public.update_contract_info_id;`
     )

--- a/src/migrations/20230217103337-migrate-contract-info-from-token-info.ts
+++ b/src/migrations/20230217103337-migrate-contract-info-from-token-info.ts
@@ -112,13 +112,11 @@ const migration: IMigration = {
     })
   },
 
-  down: async () => {
-    /**
-     * Add reverting commands here.
-     *
-     * Example:
-     * await queryInterface.dropTable('users');
-     */
+  down: async queryInterface => {
+    await queryInterface.removeConstraint('TokenInfo', 'contractInfoId')
+    await queryInterface.sequelize.query(
+      `DROP PROCEDURE IF EXISTS public.update_contract_info_id;`
+    )
   }
 }
 

--- a/src/migrations/20230217103337-migrate-contract-info-from-token-info.ts
+++ b/src/migrations/20230217103337-migrate-contract-info-from-token-info.ts
@@ -18,6 +18,11 @@ interface IMigration {
 
 const migration: IMigration = {
   up: async queryInterface => {
+    await queryInterface.addIndex('TokenInfo', ['contractInfoId'], {
+      name: 'token_info_contract_info_id_idx',
+      unique: false
+    })
+
     await queryInterface.sequelize.query(
       `
       INSERT INTO "ContractInfo" (address, "tokenType", "name", symbol, decimals, "updatedAt", "updatedMetaInfoAt")

--- a/src/migrations/20230217153917-update-token-info-table-reference-to-contract-info.ts
+++ b/src/migrations/20230217153917-update-token-info-table-reference-to-contract-info.ts
@@ -1,0 +1,41 @@
+'use strict'
+
+import 'dotenv/config'
+import 'module-alias/register'
+import 'source-map-support/register'
+
+import { QueryInterface, Sequelize } from 'sequelize'
+
+interface IMigration {
+  up: (queryInterface: QueryInterface, sequelize: Sequelize) => Promise<void>
+  down: (queryInterface: QueryInterface, sequelize: Sequelize) => Promise<void>
+}
+
+/**
+ * Typescript based sequelize migration
+ * @see https://sequelize.org/master/manual/migrations.html
+ */
+
+const migration: IMigration = {
+  up: async queryInterface => {
+    await queryInterface.addIndex('TokenInfo', ['contractInfoId'], {
+      name: 'token_info_contract_info_id_idx',
+      unique: false
+    })
+    await queryInterface.sequelize.query(
+      `ALTER TABLE ONLY "TokenInfo"
+    ADD CONSTRAINT "TokenInfo_contractInfoId_fkey" FOREIGN KEY ("contractInfoId") REFERENCES "ContractInfo"(id);`,
+      { raw: true }
+    )
+    // await queryInterface.changeColumn('TokenInfo', 'contractInfoId', {
+    //   type: DataTypes.INTEGER,
+    //   allowNull: false
+    // })
+  },
+
+  down: async () => {
+    // await queryInterface.removeConstraint('TokenInfo', 'contractInfoId')
+  }
+}
+
+export default migration

--- a/src/migrations/20230217153917-update-token-info-table-reference-to-contract-info.ts
+++ b/src/migrations/20230217153917-update-token-info-table-reference-to-contract-info.ts
@@ -18,10 +18,6 @@ interface IMigration {
 
 const migration: IMigration = {
   up: async queryInterface => {
-    await queryInterface.addIndex('TokenInfo', ['contractInfoId'], {
-      name: 'token_info_contract_info_id_idx',
-      unique: false
-    })
     await queryInterface.sequelize.query(
       `ALTER TABLE ONLY "TokenInfo"
     ADD CONSTRAINT "TokenInfo_contractInfoId_fkey" FOREIGN KEY ("contractInfoId") REFERENCES "ContractInfo"(id);`,

--- a/src/migrations/20230217153917-update-token-info-table-reference-to-contract-info.ts
+++ b/src/migrations/20230217153917-update-token-info-table-reference-to-contract-info.ts
@@ -29,8 +29,11 @@ const migration: IMigration = {
     // })
   },
 
-  down: async () => {
-    // await queryInterface.removeConstraint('TokenInfo', 'contractInfoId')
+  down: async queryInterface => {
+    await queryInterface.removeConstraint(
+      'TokenInfo',
+      'TokenInfo_contractInfoId_fkey'
+    )
   }
 }
 

--- a/src/models/ContractInfo/ContractInfo.ts
+++ b/src/models/ContractInfo/ContractInfo.ts
@@ -6,7 +6,6 @@ import {
   DataType,
   PrimaryKey,
   AutoIncrement,
-  Default,
   UpdatedAt
 } from 'sequelize-typescript'
 import { TokenType } from '@types'
@@ -55,8 +54,7 @@ export class ContractInfo extends Model<
   @Column(DataType.INTEGER)
   decimals: Maybe<number>
 
-  @AllowNull(false)
-  @Default(0)
+  @AllowNull(true)
   @Column(DataType.INTEGER)
   lastTransactionBlock: Maybe<number>
 

--- a/src/models/ContractInfo/ContractInfo.ts
+++ b/src/models/ContractInfo/ContractInfo.ts
@@ -1,0 +1,73 @@
+import {
+  AllowNull,
+  Column,
+  Model,
+  Table,
+  DataType,
+  PrimaryKey,
+  AutoIncrement,
+  Default,
+  UpdatedAt
+} from 'sequelize-typescript'
+import { TokenType } from '@types'
+
+@Table({
+  tableName: 'ContractInfo',
+  createdAt: false,
+  updatedAt: true,
+  indexes: [
+    {
+      name: 'contract_info_address_idx',
+      unique: true,
+      fields: ['address']
+    }
+  ]
+})
+export class ContractInfo extends Model<
+  Partial<ContractInfo> & Pick<ContractInfo, 'address'>
+> {
+  @PrimaryKey
+  @AutoIncrement
+  @Column(DataType.INTEGER)
+  id: number
+
+  @AllowNull(false)
+  @Column(DataType.STRING)
+  address: string
+
+  @AllowNull(true)
+  @Column(DataType.ENUM(...Object.values(TokenType)))
+  tokenType: Maybe<TokenType>
+
+  @AllowNull(true)
+  @Column(DataType.TEXT)
+  name: Maybe<string>
+
+  @AllowNull(true)
+  @Column(DataType.TEXT)
+  symbol: Maybe<string>
+
+  @AllowNull(true)
+  @Column(DataType.DECIMAL)
+  ethBalance: Maybe<BigInt>
+
+  @AllowNull(true)
+  @Column(DataType.INTEGER)
+  decimals: Maybe<number>
+
+  @AllowNull(false)
+  @Default(0)
+  @Column(DataType.INTEGER)
+  lastTransactionBlock: Maybe<number>
+
+  @AllowNull(true)
+  @Column(DataType.DATE)
+  lastTransactionAt: Maybe<Date>
+
+  @AllowNull(true)
+  @Column(DataType.DATE)
+  updatedMetaInfoAt: Maybe<Date>
+
+  @UpdatedAt
+  updatedAt: Date
+}

--- a/src/models/ContractSpam/ContractSpam.ts
+++ b/src/models/ContractSpam/ContractSpam.ts
@@ -14,7 +14,7 @@ import {
   createdAt: false,
   updatedAt: false
 })
-export class ContractInfo extends Model<Pick<ContractInfo, 'address'>> {
+export class ContractSpam extends Model<Pick<ContractSpam, 'address'>> {
   @PrimaryKey
   @AutoIncrement
   @Column(DataType.INTEGER)

--- a/src/models/TokenInfo/TokenInfo.ts
+++ b/src/models/TokenInfo/TokenInfo.ts
@@ -7,9 +7,11 @@ import {
   DataType,
   PrimaryKey,
   UpdatedAt,
-  AutoIncrement
+  AutoIncrement,
+  ForeignKey,
+  BelongsTo
 } from 'sequelize-typescript'
-import { TokenType } from '../../@types'
+import { ContractInfo } from '@models/ContractInfo/ContractInfo'
 
 @Table({
   tableName: 'TokenInfo',
@@ -35,6 +37,10 @@ import { TokenType } from '../../@types'
           [Op.is]: null
         }
       }
+    },
+    {
+      name: 'token_info_contract_info_id_idx',
+      fields: ['contractInfoId']
     }
   ]
 })
@@ -43,10 +49,6 @@ export class TokenInfo extends Model<
     TokenInfo,
     | 'address'
     | 'tokenId'
-    | 'tokenType'
-    | 'contractName'
-    | 'symbol'
-    | 'decimals'
     | 'tokenName'
     | 'tokenDescription'
     | 'imageUrl'
@@ -55,6 +57,7 @@ export class TokenInfo extends Model<
     | 'animationUrl'
     | 'youtubeUrl'
     | 'tokenUri'
+    | 'contractInfoId'
   >
 > {
   @PrimaryKey
@@ -69,22 +72,6 @@ export class TokenInfo extends Model<
   @AllowNull(true)
   @Column(DataType.STRING)
   tokenId: Maybe<string>
-
-  @AllowNull(true)
-  @Column(DataType.ENUM(...Object.values(TokenType)))
-  tokenType: Maybe<TokenType>
-
-  @AllowNull(true)
-  @Column(DataType.STRING)
-  contractName: Maybe<string>
-
-  @AllowNull(true)
-  @Column(DataType.STRING)
-  symbol: Maybe<string>
-
-  @AllowNull(true)
-  @Column(DataType.INTEGER)
-  decimals: Maybe<number>
 
   @AllowNull(true)
   @Column(DataType.STRING)
@@ -117,6 +104,14 @@ export class TokenInfo extends Model<
   @AllowNull(true)
   @Column(DataType.TEXT)
   tokenUri: Maybe<string>
+
+  @ForeignKey(() => ContractInfo)
+  @AllowNull(false)
+  @Column(DataType.INTEGER)
+  contractInfoId: number
+
+  @BelongsTo(() => ContractInfo, 'contractInfoId')
+  contractInfo: ContractInfo
 
   @UpdatedAt
   updatedAt: Date

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -1,3 +1,4 @@
+import { ContractInfo } from './ContractInfo/ContractInfo'
 import { Status } from './Status/Status'
 import { TokenInfo } from './TokenInfo/TokenInfo'
 import { TokenTransfer } from './TokenTransfer/TokenTransfer'
@@ -5,6 +6,6 @@ import { dbConnection } from './db'
 
 export const sequelize = dbConnection
 
-sequelize.addModels([Status, TokenTransfer, TokenInfo])
+sequelize.addModels([Status, TokenTransfer, TokenInfo, ContractInfo])
 
-export { Status, TokenTransfer }
+export { Status, TokenTransfer, TokenInfo, ContractInfo }

--- a/src/monitoringServer.ts
+++ b/src/monitoringServer.ts
@@ -1,3 +1,7 @@
+import 'dotenv/config'
+import 'module-alias/register'
+import 'source-map-support/register'
+
 import './lib/doom'
 import express from 'express'
 import { SyncingState } from './@types'

--- a/src/queryingServer.ts
+++ b/src/queryingServer.ts
@@ -1,3 +1,7 @@
+import 'dotenv/config'
+import 'module-alias/register'
+import 'source-map-support/register'
+
 import './lib/doom'
 import { json } from 'body-parser'
 import express from 'express'

--- a/src/scripts/queueUpdateContractInfo.ts
+++ b/src/scripts/queueUpdateContractInfo.ts
@@ -4,7 +4,50 @@ import 'dotenv/config'
 import 'module-alias/register'
 import 'source-map-support/register'
 
-import { queueContractInfoBackfill } from '@lib/queueContractInfoJobs'
+import { Op } from 'sequelize'
+import {
+  IContractInfoJobDetailsByTokenAddress,
+  queueContractInfoByTokenAddressJobs,
+  TBackfill
+} from '@lib/queueContractInfoJobs'
+import { ContractInfo } from '@models/index'
+
+async function queueContractInfoBackfill({
+  howMany,
+  unproccessedOnly = true,
+  minId
+}: TBackfill) {
+  const whereClause =
+    minId || unproccessedOnly
+      ? {
+          ...(minId
+            ? {
+                id: {
+                  [Op.gte]: minId
+                }
+              }
+            : {}),
+          ...(unproccessedOnly
+            ? {
+                lastTransactionBlock: { [Op.is]: null }
+              }
+            : undefined)
+        }
+      : undefined
+
+  const contracts = await ContractInfo.findAll({
+    where: whereClause,
+    limit: howMany ? +howMany : undefined,
+    order: [['id', 'asc']]
+  })
+
+  const queueTokens: IContractInfoJobDetailsByTokenAddress[] = contracts.map(
+    contract => ({
+      tokenAddress: contract.address
+    })
+  )
+  await queueContractInfoByTokenAddressJobs(queueTokens)
+}
 
 async function main() {
   const howMany = +process.argv[3] ? +process.argv[3] : undefined

--- a/src/scripts/queueUpdateContractInfo.ts
+++ b/src/scripts/queueUpdateContractInfo.ts
@@ -7,7 +7,7 @@ import 'source-map-support/register'
 import { Op } from 'sequelize'
 import {
   IContractInfoJobDetailsByTokenAddress,
-  queueContractInfoByTokenAddressJobs,
+  queueUpdateContractInfoByTokenAddress,
   TBackfill
 } from '@lib/queueContractInfoJobs'
 import { ContractInfo } from '@models/index'
@@ -46,7 +46,7 @@ async function queueContractInfoBackfill({
       tokenAddress: contract.address
     })
   )
-  await queueContractInfoByTokenAddressJobs(queueTokens)
+  await queueUpdateContractInfoByTokenAddress(queueTokens)
 }
 
 async function main() {

--- a/src/scripts/queueUpdateContractInfo.ts
+++ b/src/scripts/queueUpdateContractInfo.ts
@@ -1,0 +1,25 @@
+'use strict'
+
+import 'dotenv/config'
+import 'module-alias/register'
+import 'source-map-support/register'
+
+import { queueContractInfoBackfill } from '@lib/queueContractInfoJobs'
+
+async function main() {
+  const howMany = +process.argv[3] ? +process.argv[3] : undefined
+  const unproccessedOnly = new Boolean(
+    process.argv[4] !== undefined ? process.argv[4] : true
+  ).valueOf()
+  const minId = process.argv[5] ? +process.argv[5] : undefined
+
+  if (!howMany) {
+    throw new Error(
+      `Missing howMany to process and if process unproccesed only`
+    )
+  }
+
+  await queueContractInfoBackfill({ howMany, unproccessedOnly, minId })
+}
+
+main()

--- a/src/scripts/queueUpdateContractInfo.ts
+++ b/src/scripts/queueUpdateContractInfo.ts
@@ -7,7 +7,7 @@ import 'source-map-support/register'
 import { Op } from 'sequelize'
 import {
   IContractInfoJobDetailsByTokenAddress,
-  queueUpdateContractInfoByTokenAddress,
+  queueContractInfoByTokenAddressJobs,
   TBackfill
 } from '@lib/queueContractInfoJobs'
 import { ContractInfo } from '@models/index'
@@ -46,7 +46,7 @@ async function queueContractInfoBackfill({
       tokenAddress: contract.address
     })
   )
-  await queueUpdateContractInfoByTokenAddress(queueTokens)
+  await queueContractInfoByTokenAddressJobs(queueTokens)
 }
 
 async function main() {

--- a/src/scripts/updateContractInfo.ts
+++ b/src/scripts/updateContractInfo.ts
@@ -1,0 +1,33 @@
+'use strict'
+
+import 'dotenv/config'
+import 'module-alias/register'
+import 'source-map-support/register'
+
+import { getEthClient } from '@lib/getEthClient'
+import updateContractInfo from '@lib/updateContractInfo'
+import { ContractInfo } from '@models/index'
+
+async function main() {
+  const contractAddress = process.argv[3]
+  await updateContractInfo({ tokenAddress: contractAddress, full: false })
+
+  const client = await getEthClient()
+  const contractInfo = await ContractInfo.findOne({
+    where: {
+      address: contractAddress.toLowerCase()
+    },
+    logging: console.log
+  })
+  if (!contractInfo) {
+    return
+  }
+  const logs = await client.getLogs({
+    address: contractAddress,
+    fromBlock: contractInfo.lastTransactionBlock || 0
+  })
+
+  console.log(logs)
+}
+
+main()

--- a/src/scripts/updateContractInfo.ts
+++ b/src/scripts/updateContractInfo.ts
@@ -4,11 +4,18 @@ import 'dotenv/config'
 import 'module-alias/register'
 import 'source-map-support/register'
 
-import updateContractInfo from '@lib/updateContractInfo'
+import { updateContractInfoByTokenAddress } from '@lib/updateContractInfo'
 
 async function main() {
   const contractAddress = process.argv[3]
-  await updateContractInfo({ tokenAddress: contractAddress })
+  const blockNumber = process.argv[4] ? +process.argv[4] : undefined
+  const fullUpdate = process.argv[5] === 'true'
+
+  await updateContractInfoByTokenAddress({
+    tokenAddress: contractAddress,
+    transferBlockNumber: blockNumber,
+    fullUpdate
+  })
 }
 
 main()

--- a/src/scripts/updateContractInfo.ts
+++ b/src/scripts/updateContractInfo.ts
@@ -4,30 +4,11 @@ import 'dotenv/config'
 import 'module-alias/register'
 import 'source-map-support/register'
 
-import { getEthClient } from '@lib/getEthClient'
 import updateContractInfo from '@lib/updateContractInfo'
-import { ContractInfo } from '@models/index'
 
 async function main() {
   const contractAddress = process.argv[3]
-  await updateContractInfo({ tokenAddress: contractAddress, full: false })
-
-  const client = await getEthClient()
-  const contractInfo = await ContractInfo.findOne({
-    where: {
-      address: contractAddress.toLowerCase()
-    },
-    logging: console.log
-  })
-  if (!contractInfo) {
-    return
-  }
-  const logs = await client.getLogs({
-    address: contractAddress,
-    fromBlock: contractInfo.lastTransactionBlock || 0
-  })
-
-  console.log(logs)
+  await updateContractInfo({ tokenAddress: contractAddress })
 }
 
 main()

--- a/src/tokenInfoServer.ts
+++ b/src/tokenInfoServer.ts
@@ -36,7 +36,10 @@ async function consumeQueue(): Promise<undefined> {
     queueUrl: TOKEN_INFO_QUEUE_URL,
     handleMessage: async sqsMessage => {
       const data: ITokenInfoJobDetails = JSON.parse(sqsMessage.Body!)
-      await updateTokenInfo(data.tokenAddress, data.tokenId)
+      await updateTokenInfo({
+        tokenAddress: data.tokenAddress,
+        tokenId: data.tokenId
+      })
     }
   })
 

--- a/src/tokenInfoServer.ts
+++ b/src/tokenInfoServer.ts
@@ -1,3 +1,7 @@
+import 'dotenv/config'
+import 'module-alias/register'
+import 'source-map-support/register'
+
 import './lib/doom'
 import cluster from 'cluster'
 import { cpus } from 'os'

--- a/src/tokenInfoServer.ts
+++ b/src/tokenInfoServer.ts
@@ -36,10 +36,7 @@ async function consumeQueue(): Promise<undefined> {
     queueUrl: TOKEN_INFO_QUEUE_URL,
     handleMessage: async sqsMessage => {
       const data: ITokenInfoJobDetails = JSON.parse(sqsMessage.Body!)
-      await updateTokenInfo({
-        tokenAddress: data.tokenAddress,
-        tokenId: data.tokenId
-      })
+      await updateTokenInfo(data.tokenAddress, data.tokenId)
     }
   })
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,7 +23,9 @@
     "declaration": true,
     "paths": {
       "@models/*": ["models/*"],
-      "@utils/*": ["utils/*"]
+      "@utils/*": ["utils/*"],
+      "@lib/*": ["lib/*"],
+      "@types/*": ["@types/*"]
     }
   },
   "include": ["src/**/*"],


### PR DESCRIPTION
Ran on goerli and mainnet already on upstream

- New Contract Info table and migrations (premigrated for large data sets)
  - address, name, symbol, tokenType, decimals columns
  - Eth Balance added per contract
  - Last Transaction block and date added per contract
- Create/Update contract info on (using queues):
  - backfill (create once)
  - new transfer event (create contract info new if needed)
  - on any new block (only for existing contracts only for non transfer interactions)
  - enrichment
  - token info job (create if contractInfo can't be found)
 - Added aliases for `lib` and `@types`
 - Updated helm charts to start new contractInfoServer (queue monitoring)
 - Attempt Fixing helm release (when only numeric sha -7 chars are found, heml treats it like a exponential number and its not a valid name for helm deployments) (this should be a separate PR ideally)

Already update contractInfo and tokenInfo where possible on our existing DB due to large data